### PR TITLE
Fix RunAs RunCommand for Linux (rewrite sort-of)

### DIFF
--- a/main/exec.go
+++ b/main/exec.go
@@ -37,6 +37,7 @@ func Exec(ctx *log.Context, cmd, workdir string, stdout, stderr io.WriteCloser, 
 	exitCode := 0 // TODO: return exit code and execution state
 
 	if cfg.publicSettings.RunAsUser != "" {
+		ctx.Log("message", "RunAsUser is "+cfg.publicSettings.RunAsUser)
 
 		// Check prefix ("/var/lib/waagent/run-command-handler") exists in script path for ex. /var/lib/waagent/run-command-handler/download/<runcommandName>/0/script.sh
 		if !strings.HasPrefix(scriptPath, dataDir) {
@@ -55,13 +56,13 @@ func Exec(ctx *log.Context, cmd, workdir string, stdout, stderr io.WriteCloser, 
 		scriptLines := [4]string{}
 
 		// Create runAsScriptDirectoryPath and its intermediate directories if they do not exist
-		scriptLines[0] = fmt.Sprintf("mkdir -p -m a=rwx %s", runAsScriptDirectoryPath)
+		scriptLines[0] = fmt.Sprintf("mkdir -p -m u=rwx %s", runAsScriptDirectoryPath)
 
 		// Copy script at scriptPath to runAsScriptDirectoryPath
 		scriptLines[1] = fmt.Sprintf("cp %s %s", scriptPath, runAsScriptDirectoryPath)
 
 		// Provide read and execute permissions to RunAsUser on .sh file at runAsScriptFilePath
-		scriptLines[2] = fmt.Sprintf("chmod 0555 %s", runAsScriptFilePath)
+		scriptLines[2] = fmt.Sprintf("chown -R %s %s", cfg.publicSettings.RunAsUser, runAsScriptDirectoryPath)
 
 		// echo pipes the RunAsPassword to sudo -S for RunAsUser instead of prompting the password interactively from user and blocking.
 		// echo <cfg.protectedSettings.RunAsPassword> | sudo -S -u <cfg.publicSettings.RunAsUser> <command>

--- a/main/exec.go
+++ b/main/exec.go
@@ -77,7 +77,7 @@ func Exec(ctx *log.Context, cmd, workdir string, stdout, stderr io.WriteCloser, 
 			return failedExitCodeGeneral, errors.Wrapf(runAsScriptContainerScriptCreateError, fmt.Sprintf("Failed to create RunAs script '%s'. Contact ICM team AzureRT\\Extensions for this service error.", runAsScriptContainerScriptFilePath))
 		}
 		// Provide permissions to root to read + execute runAsScript.sh
-		runAsScriptContainerScriptChmodError := os.Chmod(runAsScriptContainerScriptFilePath, 0555)
+		runAsScriptContainerScriptChmodError := os.Chmod(runAsScriptContainerScriptFilePath, 0550)
 		if runAsScriptContainerScriptChmodError != nil {
 			return failedExitCodeGeneral, errors.Wrapf(runAsScriptContainerScriptCreateError, fmt.Sprintf("Failed to provide execute permissions to root for RunAs script '%s'. Contact ICM team AzureRT\\Extensions for this service error.", runAsScriptContainerScriptFilePath))
 		}

--- a/main/main.go
+++ b/main/main.go
@@ -136,7 +136,7 @@ func main() {
 	instanceView.Error = stderr
 	// Use this workaround to throw a user-friendly error message when RunAs user does not exist on VM.
 	// Using this workaround because of Bug 16003130: [RCv2 Linux] user.Lookup() does not return any error if the user does not exist.
-	if instanceView.Error != "" || strings.Contains(instanceView.Error, "unknown user") || strings.Contains(instanceView.Error, "invalid user") {
+	if instanceView.Error != "" && (strings.Contains(instanceView.Error, "unknown user") || strings.Contains(instanceView.Error, "invalid user")) {
 		instanceView.Error = fmt.Sprintf("'%s'. Looks like user does not exist. For RunAs to work properly, contact admin of VM and make sure RunAs user is added on the VM and user has access to resources accessed by the Run Command (Directories, Files, Network etc.). Refer: https://aka.ms/RunCommandManagedLinux", instanceView.Error)
 	}
 

--- a/main/main.go
+++ b/main/main.go
@@ -116,10 +116,10 @@ func main() {
 	reportInstanceView(ctx, hEnv, extensionName, seqNum, StatusTransitioning, cmd, &instanceView)
 
 	// execute the subcommand
-	stdout, stderr, err := cmd.invoke(ctx, hEnv, &instanceView, extensionName, seqNum)
-	if err != nil {
-		ctx.Log("event", "failed to handle", "error", err)
-		instanceView.ExecutionMessage = "Execution failed: " + err.Error()
+	stdout, stderr, cmdInvokeError := cmd.invoke(ctx, hEnv, &instanceView, extensionName, seqNum)
+	if cmdInvokeError != nil {
+		ctx.Log("event", "failed to handle", "error", cmdInvokeError)
+		instanceView.ExecutionMessage = "Execution failed: " + cmdInvokeError.Error()
 		instanceView.EndTime = time.Now().UTC().Format(time.RFC3339)
 		instanceView.ExitCode = cmd.failExitCode
 		instanceView.ExecutionState = Failed

--- a/main/main.go
+++ b/main/main.go
@@ -122,6 +122,7 @@ func main() {
 		instanceView.ExecutionMessage = "Execution failed: " + err.Error()
 		instanceView.EndTime = time.Now().UTC().Format(time.RFC3339)
 		instanceView.ExitCode = cmd.failExitCode
+		instanceView.ExecutionState = Failed
 		reportInstanceView(ctx, hEnv, extensionName, seqNum, StatusSuccess, cmd, &instanceView)
 		os.Exit(cmd.failExitCode)
 	} else { // No error. succeeded

--- a/main/main.go
+++ b/main/main.go
@@ -134,6 +134,12 @@ func main() {
 
 	instanceView.Output = stdout
 	instanceView.Error = stderr
+	// Use this workaround to throw a user-friendly error message when RunAs user does not exist on VM.
+	// Using this workaround because of Bug 16003130: [RCv2 Linux] user.Lookup() does not return any error if the user does not exist.
+	if instanceView.Error != "" || strings.Contains(instanceView.Error, "unknown user") || strings.Contains(instanceView.Error, "invalid user") {
+		instanceView.Error = fmt.Sprintf("'%s'. Looks like user does not exist. For RunAs to work properly, contact admin of VM and make sure RunAs user is added on the VM and user has access to resources accessed by the Run Command (Directories, Files, Network etc.). Refer: https://aka.ms/RunCommandManagedLinux", instanceView.Error)
+	}
+
 	reportInstanceView(ctx, hEnv, extensionName, seqNum, StatusSuccess, cmd, &instanceView)
 	ctx.Log("event", "end")
 }


### PR DESCRIPTION
- Fix running RunCommand as a different user than root (as RunAsUser passed in parameter)
- We would execute the script on behalf of the RunAsUser. However, the VM owner/admin needs to provide access to RunAsUser for resources like files, directories, network etc. for a successful execution.
- Successful RunCommand PUT request:
https://dataexplorer.azure.com/clusters/azcrp/databases/crp_allprod?query=H4sIAAAAAAAAA3MsyAzML3YtS80r4eWqUSjPSC1KVQgoSk3OLE4NycxNDS5JzC1QsLNVSEksSS0BCmgYGRgZ6Roa6BqZaiok5qVgKrbBotZMUwFhfH5BalFiSWZ+nmeKgq2tglKiWZJBanKika6FUaKhrkmqkYmupYVlmm6ycXJKSpqxsYGpeaISAExAheKpAAAA

ApiQosEvent
| where PreciseTimeStamp >= datetime(2022-10-25) and PreciseTimeStamp < datetime(2022-10-26) 
| where operationId == "a6b0eca2-82a1-4e24-989f-c3cddf33057a"

- Fiddler traces are at \\viv11\E$\Logs\RunAsRunCommandLinuxWorking.saz
- screenshot:
![image](https://user-images.githubusercontent.com/25780318/197869880-c33b9e71-5784-4154-948f-48b18a24d328.png)

