### PR TITLE
Do not write RunAs password in script file

### DIFF
--- a/main/cmds.go
+++ b/main/cmds.go
@@ -199,9 +199,7 @@ func enable(ctx *log.Context, h HandlerEnvironment, report *RunCommandInstanceVi
 	outputFilePosition, err = reportOutputToBlob(stdoutF, outputBlobRef, outputFilePosition)
 	errorFilePosition, err = reportOutputToBlob(stderrF, errorBlobRef, errorFilePosition)
 
-	// Always report nil for error because extension should not fail if script throws error
-	// Execution error still will be reported in the error stream
-	return stdoutTail, stderrTail, nil
+	return stdoutTail, stderrTail, runErr
 }
 
 // reportOutputToBlob save a file (from seeking position to the end of the file) to append blob. Returns the new position (end of the file)

--- a/main/exec.go
+++ b/main/exec.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -27,7 +27,6 @@ func Exec(ctx *log.Context, cmd, workdir string, stdout, stderr io.WriteCloser, 
 	defer stderr.Close()
 
 	scriptPath := cmd
-	scriptPathDirectory := filepath.Dir(cmd)
 
 	commandArgs, err := SetEnvironmentVariables(cfg)
 	// Add command args if any. Unnamed arguments go in 'commandArgs'. Named arguments are set as environment variables so the'd be available within the script.
@@ -52,46 +51,66 @@ func Exec(ctx *log.Context, cmd, workdir string, stdout, stderr io.WriteCloser, 
 		runAsScriptFilePath := filepath.Join(fmt.Sprintf(runAsDir, cfg.publicSettings.RunAsUser), downloadPathSuffix)
 		runAsScriptDirectoryPath := filepath.Dir(runAsScriptFilePath) // Get directory of runAsScript that doesn't exist yet
 
-		// Create a 4-line script to be run as below to be able to Run As different user.
-		scriptLines := [4]string{}
-
 		// Create runAsScriptDirectoryPath and its intermediate directories if they do not exist
-		scriptLines[0] = fmt.Sprintf("mkdir -p -m u=rwx %s", runAsScriptDirectoryPath)
+		os.MkdirAll(runAsScriptDirectoryPath, 0777)
 
-		// Copy script at scriptPath to runAsScriptDirectoryPath
-		scriptLines[1] = fmt.Sprintf("cp %s %s", scriptPath, runAsScriptDirectoryPath)
+		/// Copy source script at scriptPath to runAsScriptDirectoryPath
+		// Get reference to source script by opening it
+		sourceScriptFile, sourceScriptFileOpenError := os.OpenFile(scriptPath, os.O_RDONLY, 0400)
+		if sourceScriptFileOpenError != nil {
+			errMessage := "Failed to open source script. Contact ICM team AzureRT\\Extensions for this service error."
+			ctx.Log("message", errMessage+fmt.Sprintf(" Source script file is '%s'", scriptPath))
+			return failedExitCodeGeneral, errors.Wrapf(sourceScriptFileOpenError, errMessage)
+		}
+
+		destScriptFile, destScriptCreateError := os.Create(runAsScriptFilePath)
+		if destScriptCreateError != nil {
+			errMessage := "Failed to create script for Run As in Run As directory. Contact ICM team AzureRT\\Extensions for this service error."
+			ctx.Log("message", errMessage+fmt.Sprintf(" Destination runAs script file is '%s'", runAsScriptFilePath))
+			return failedExitCodeGeneral, errors.Wrapf(destScriptCreateError, errMessage)
+		}
+		_, runAsScriptCopyError := io.Copy(destScriptFile, sourceScriptFile)
+		if runAsScriptCopyError != nil {
+			errMessage := fmt.Sprintf("Failed to copy script file '%s' to Run As path '%s'. Contact ICM team AzureRT\\Extensions for this service error.", scriptPath, runAsScriptFilePath)
+			ctx.Log("message", errMessage)
+			return failedExitCodeGeneral, errors.Wrapf(runAsScriptCopyError, errMessage)
+		}
+		sourceScriptFile.Close()
+		destScriptFile.Close()
 
 		// Provide read and execute permissions to RunAsUser on .sh file at runAsScriptFilePath
-		scriptLines[2] = fmt.Sprintf("chown -R %s %s", cfg.publicSettings.RunAsUser, runAsScriptDirectoryPath)
+		lookedUpUser, lookupUserError := user.Lookup(cfg.publicSettings.RunAsUser)
+		if lookupUserError != nil {
+			errMessage := fmt.Sprintf("Failed to lookup RunAs user '%s'. Looks like user does not exist. For RunAs to work properly, contact admin of VM and make sure RunAs user is added on the VM and user has access to resources accessed by the Run Command (Directories, Files, Network etc.). Refer: https://aka.ms/RunCommandManagedLinux", cfg.publicSettings.RunAsUser)
+			ctx.Log("message", errMessage)
+			return failedExitCodeGeneral, errors.Wrapf(lookupUserError, errMessage)
+		}
+
+		lookedUpUserUid, lookedUpUserUidErr := strconv.Atoi(lookedUpUser.Uid)
+		if lookedUpUserUidErr != nil {
+			errMessage := "Failed to determine RunAs user's Uid and Guid . Contact ICM team AzureRT\\Extensions for this service error."
+			ctx.Log("message", errMessage)
+			return failedExitCodeGeneral, errors.Wrapf(lookedUpUserUidErr, errMessage)
+		}
+
+		runAsScriptChownError := os.Chown(runAsScriptFilePath, lookedUpUserUid, os.Getegid())
+		if runAsScriptChownError != nil {
+			errMessage := fmt.Sprintf("Failed to change owner of file '%s' to RunAs user '%s'. Contact ICM team AzureRT\\Extensions for this service error.", runAsScriptFilePath, cfg.publicSettings.RunAsUser)
+			ctx.Log("message", errMessage)
+			return failedExitCodeGeneral, errors.Wrapf(runAsScriptChownError, errMessage)
+		}
+
+		runAsScriptChmodError := os.Chmod(runAsScriptFilePath, 0550)
+		if runAsScriptChmodError != nil {
+			errMessage := fmt.Sprintf("Failed to change permissions to execute for file '%s' for RunAs user '%s'. Contact ICM team AzureRT\\Extensions for this service error.", runAsScriptFilePath, cfg.publicSettings.RunAsUser)
+			ctx.Log("message", errMessage)
+			return failedExitCodeGeneral, errors.Wrapf(runAsScriptChmodError, errMessage)
+		}
 
 		// echo pipes the RunAsPassword to sudo -S for RunAsUser instead of prompting the password interactively from user and blocking.
 		// echo <cfg.protectedSettings.RunAsPassword> | sudo -S -u <cfg.publicSettings.RunAsUser> <command>
-		scriptLines[3] = fmt.Sprintf("echo %s | sudo -S -u %s %s", cfg.protectedSettings.RunAsPassword, cfg.publicSettings.RunAsUser, runAsScriptFilePath+commandArgs)
-
-		// Create a shell script file that is run by root at <scriptPathDirectory>/runAsScript.sh that contains script that is run as RunAsUser
-		// ex. /var/lib/waagent/run-command-handler/download/<RunCommandName>/<sequenceNumber>/runAsScript.sh
-		// Create a writer
-		runAsScriptContainerScriptFilePath := filepath.Join(scriptPathDirectory, "runAsScript.sh")
-		runAsScriptContainerScript, runAsScriptContainerScriptCreateError := os.Create(runAsScriptContainerScriptFilePath)
-		if runAsScriptContainerScriptCreateError != nil {
-			return failedExitCodeGeneral, errors.Wrapf(runAsScriptContainerScriptCreateError, fmt.Sprintf("Failed to create RunAs script '%s'. Contact ICM team AzureRT\\Extensions for this service error.", runAsScriptContainerScriptFilePath))
-		}
-		// Provide permissions to root to read + execute runAsScript.sh
-		runAsScriptContainerScriptChmodError := os.Chmod(runAsScriptContainerScriptFilePath, 0550)
-		if runAsScriptContainerScriptChmodError != nil {
-			return failedExitCodeGeneral, errors.Wrapf(runAsScriptContainerScriptCreateError, fmt.Sprintf("Failed to provide execute permissions to root for RunAs script '%s'. Contact ICM team AzureRT\\Extensions for this service error.", runAsScriptContainerScriptFilePath))
-		}
-
-		runAsScriptContainerScriptFileWriter := bufio.NewWriter(runAsScriptContainerScript)
-		for _, line := range scriptLines {
-			runAsScriptContainerScriptFileWriter.WriteString(line + "\n")
-		}
-		runAsScriptContainerScriptFileWriter.Flush() // Flush buffer
-		runAsScriptContainerScript.Close()
-
-		// .sh script file at runAsScriptContainerScriptFilePath would contain four lines of script to execute the Run Command as RunAsUser
-		cmd = runAsScriptContainerScriptFilePath
-		ctx.Log("message", "RunAs script is "+cmd)
+		cmd = fmt.Sprintf("echo %s | sudo -S -u %s %s", cfg.protectedSettings.RunAsPassword, cfg.publicSettings.RunAsUser, runAsScriptFilePath+commandArgs)
+		ctx.Log("message", "RunAs cmd is "+cmd)
 	}
 
 	var command *exec.Cmd

--- a/main/main.go
+++ b/main/main.go
@@ -134,12 +134,6 @@ func main() {
 
 	instanceView.Output = stdout
 	instanceView.Error = stderr
-	// Use this workaround to throw a user-friendly error message when RunAs user does not exist on VM.
-	// Using this workaround because of Bug 16003130: [RCv2 Linux] user.Lookup() does not return any error if the user does not exist.
-	if instanceView.Error != "" && (strings.Contains(instanceView.Error, "unknown user") || strings.Contains(instanceView.Error, "invalid user")) {
-		instanceView.Error = fmt.Sprintf("'%s'. Looks like user does not exist. For RunAs to work properly, contact admin of VM and make sure RunAs user is added on the VM and user has access to resources accessed by the Run Command (Directories, Files, Network etc.). Refer: https://aka.ms/RunCommandManagedLinux", instanceView.Error)
-	}
-
 	reportInstanceView(ctx, hEnv, extensionName, seqNum, StatusSuccess, cmd, &instanceView)
 	ctx.Log("event", "end")
 }


### PR DESCRIPTION
- Remove the usage of runAsScript.sh, instead reuse the source script file
- Do not write RunAs password in script file