### PR TITLE
Increment RunCommand v2 Linux version to 1.3.2 for GA

### DIFF
--- a/misc/manifest.xml
+++ b/misc/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.CPlat.Core</ProviderNameSpace>
   <Type>RunCommandHandlerLinux</Type>
-  <Version>1.3.1</Version>
+  <Version>1.3.2</Version>
   <Label>Microsoft Azure Run Command Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
Increment RunCommand v2 Linux version to 1.3.2 for GA deployment