### PR TITLE
[RCV2 Linux] Support nested directories for output and error blobs

### DIFF
--- a/main/cmds.go
+++ b/main/cmds.go
@@ -132,7 +132,7 @@ func enable(ctx *log.Context, h HandlerEnvironment, report *RunCommandInstanceVi
 	// Later the full extension output will be reported
 	statusToReport := StatusTransitioning
 	if cfg.AsyncExecution {
-		ctx.Log("message", "anycExecution is true - report success")
+		ctx.Log("message", "asycExecution is true - report success")
 		statusToReport = StatusSuccess
 		reportInstanceView(ctx, h, extName, seqNum, statusToReport, cmd{nil, "Enable", true, nil, 3}, report)
 	}
@@ -140,6 +140,7 @@ func enable(ctx *log.Context, h HandlerEnvironment, report *RunCommandInstanceVi
 	var outputBlobRef *storage.Blob = nil
 	outputFilePosition := int64(0)
 	if cfg.OutputBlobURI != "" && cfg.protectedSettings.OutputBlobSASToken != "" {
+		ctx.Log("message", fmt.Sprintf("outputBlobURI is '%s'", cfg.OutputBlobURI))
 		outputBlobRef, err = download.CreateAppendBlob(cfg.OutputBlobURI, cfg.protectedSettings.OutputBlobSASToken)
 		if err != nil {
 			ctx.Log("message", "error creating output blob", "error", err)

--- a/pkg/download/blob.go
+++ b/pkg/download/blob.go
@@ -78,10 +78,10 @@ func GetSASBlob(blobURI, blobSas, targetDir string) (string, error) {
 		return "", errors.Wrapf(err, "unable to open storage container: %q", blobURI)
 	}
 
-	// Extract the file name only
-	fileName := getFileName(blobURI)
+	// Extract the llob path after container name
+	fileName, blobPathError := getBlobPathAfterContainerName(blobURI, containerRef.Name)
 	if fileName == "" {
-		return "", fmt.Errorf("cannot extract file name from URL: %q", blobURI)
+		return "", errors.Wrapf(blobPathError, "cannot extract blob path name from URL: %q", blobURI)
 	}
 
 	blobref := containerRef.GetBlobReference(fileName)
@@ -121,13 +121,13 @@ func CreateAppendBlob(blobURI, blobSas string) (*storage.Blob, error) {
 		return nil, err
 	}
 
-	fileName := getFileName(blobURI)
+	fileName, blobPathError := getBlobPathAfterContainerName(blobURI, containerRef.Name)
 	if fileName == "" {
-		return nil, fmt.Errorf("cannot extract file name from URL: %q", blobURI)
+		return nil, errors.Wrapf(blobPathError, "cannot extract blob path name from URL: %q", blobURI)
 	}
 
 	blobref := containerRef.GetBlobReference(fileName)
-	err = blobref.PutAppendBlob(nil) // Create the page blob
+	err = blobref.PutAppendBlob(nil) // Create the append blob
 	if err != nil {
 		return nil, err
 	}
@@ -135,11 +135,21 @@ func CreateAppendBlob(blobURI, blobSas string) (*storage.Blob, error) {
 	return blobref, nil
 }
 
-// Extract the file name only from the blob uri
-func getFileName(blobURI string) string {
-	s := strings.Split(blobURI, "/")
-	if len(s) > 0 {
-		return s[len(s)-1]
+// Extract the suffix after the container name from blob uri
+// Example: blobURI - https://mystorageaccount.blob.core.windows.net/mycontainer/dir2/dir3/outputL.txt,
+// Returns "dir2/dir3/outputL.txt" (Blobs would be created under the container under nested directories mycontainer/dir2/dir3 as expected)
+func getBlobPathAfterContainerName(blobURI string, containerName string) (string, error) {
+	blobURL, err := url.Parse(blobURI)
+	if err != nil {
+		return "", err
 	}
-	return ""
+
+	containerNameSearchString := containerName + "/"
+	blobPathWithoutHost := blobURL.Path
+	index := strings.Index(blobPathWithoutHost, containerNameSearchString)
+	if index >= 0 {
+		return blobPathWithoutHost[index+len(containerNameSearchString):], nil
+	} else {
+		return "", errors.New(fmt.Sprintf("Unable to find '%s' in blobURI '%s'. Unable to get blob path suffix after container name.", containerNameSearchString, blobURI))
+	}
 }


### PR DESCRIPTION
- Support writing to blobs under nested directories under container like for ex. https://mystorageaccount.blob.core.windows.net/mycontainer/dir2/dir3/outputL.txt
- This fixes bug https://msazure.visualstudio.com/One/_workitems/edit/15173484 