### PR TITLE
Track Request ID, Response ID, and Response Code + Add response-code-specific error messages

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ github.com/Azure/go-autorest/autorest/adal v0.9.21 h1:jjQnVFXPfekaqb8vIsv2G1lxsh
 github.com/Azure/go-autorest/autorest/adal v0.9.21/go.mod h1:zua7mBUaCc5YnSLKYgGJR/w5ePdMDA6H56upLsHzA9U=
 github.com/Azure/go-autorest/autorest/date v0.3.0 h1:7gUk1U5M/CQbp9WoqinNzJar+8KY+LPI6wiWrP/myHw=
 github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
+github.com/Azure/go-autorest/autorest/mocks v0.4.1 h1:K0laFcLE6VLTOwNgSxaGbUcLPuGXlNkbVvq4cW4nIHk=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 github.com/Azure/go-autorest/autorest/mocks v0.4.2 h1:PGN4EDXnuQbojHbU0UWoNvmu9AGVwYHG9/fkDYhtAfw=
 github.com/Azure/go-autorest/autorest/mocks v0.4.2/go.mod h1:Vy7OitM9Kei0i1Oj+LvyAWMXJHeKH1MVlzFugfVrmyU=

--- a/pkg/download/blob.go
+++ b/pkg/download/blob.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/Azure/run-command-handler-linux/pkg/blobutil"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -30,7 +31,11 @@ func (b blobDownload) GetRequest() (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	return http.NewRequest("GET", url, nil)
+	req, error := http.NewRequest("GET", url, nil)
+	if req != nil {
+		req.Header.Set(xMsClientRequestIdHeaderName, uuid.New().String())
+	}
+	return req, error
 }
 
 // getURL returns publicly downloadable URL of the Azure Blob

--- a/pkg/download/blob_test.go
+++ b/pkg/download/blob_test.go
@@ -11,7 +11,12 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/Azure/run-command-handler-linux/pkg/blobutil"
+	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/require"
+)
+
+var (
+	testctx = log.NewContext(log.NewNopLogger())
 )
 
 func Test_blobDownload_validateInputs(t *testing.T) {
@@ -72,9 +77,10 @@ func Test_blobDownload_fails_badCreds(t *testing.T) {
 		Container:   "foocontainer",
 	})
 
-	status, _, err := Download(d)
+	status, _, err := Download(testctx, d)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "Status code 403 while downloading blob")
+	require.Contains(t, err.Error(), "Please verify the machine has network connectivity")
+	require.Contains(t, err.Error(), "403")
 	require.Equal(t, status, http.StatusForbidden)
 }
 
@@ -85,7 +91,7 @@ func Test_blobDownload_fails_urlNotFound(t *testing.T) {
 		Container:   "foocontainer",
 	})
 
-	_, _, err := Download(d)
+	_, _, err := Download(testctx, d)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "http request failed:")
 }
@@ -145,12 +151,63 @@ func Test_blobDownload_actualBlob(t *testing.T) {
 		Blob:        name,
 		StorageBase: base,
 	})
-	_, body, err := Download(d)
+	_, body, err := Download(testctx, d)
 	require.Nil(t, err)
 	defer body.Close()
 	b, err := ioutil.ReadAll(body)
 	require.Nil(t, err)
 	require.EqualValues(t, chunk, b, "retrieved body is different body=%d chunk=%d", len(b), len(chunk))
+}
+
+func Test_blobDownload_fails_actualBlob404(t *testing.T) {
+	acct := os.Getenv("AZURE_STORAGE_ACCOUNT")
+	key := os.Getenv("AZURE_STORAGE_ACCESS_KEY")
+	if acct == "" || key == "" {
+		t.Skipf("Skipping: AZURE_STORAGE_ACCOUNT or AZURE_STORAGE_ACCESS_KEY not specified to run this test")
+	}
+	base := storage.DefaultBaseURL
+
+	blobName := "<BLOB THAT DOESN'T EXIST>"
+	containerName := "<CONTAINER NAME>"
+
+	// Get the blob via downloader
+	d := NewBlobDownload(acct, key, blobutil.AzureBlobRef{
+		Container:   containerName,
+		Blob:        blobName,
+		StorageBase: base,
+	})
+	code, _, err := Download(testctx, d)
+	require.NotNil(t, err)
+	require.Equal(t, code, http.StatusNotFound)
+	require.Contains(t, err.Error(), "because it does not exist")
+	require.Contains(t, err.Error(), "Not Found")
+	require.Contains(t, err.Error(), "Service request ID")
+}
+
+func Test_blobDownload_fails_actualBlob409(t *testing.T) {
+	// before running this test, go to your storage account on portal > Configuration and disable Blob public access
+	acct := os.Getenv("AZURE_STORAGE_ACCOUNT")
+	key := os.Getenv("AZURE_STORAGE_ACCESS_KEY")
+	if acct == "" || key == "" {
+		t.Skipf("Skipping: AZURE_STORAGE_ACCOUNT or AZURE_STORAGE_ACCESS_KEY not specified to run this test")
+	}
+	base := storage.DefaultBaseURL
+
+	blobName := "<BLOB NAME>"
+	containerName := "<CONTAINER NAME>"
+
+	// Get the blob via downloader
+	d := NewBlobDownload(acct, key, blobutil.AzureBlobRef{
+		Container:   containerName,
+		Blob:        blobName,
+		StorageBase: base,
+	})
+	code, _, err := Download(testctx, d)
+	require.NotNil(t, err)
+	require.Equal(t, code, http.StatusConflict)
+	require.Contains(t, err.Error(), "Please verify the machine has network connectivity")
+	require.Contains(t, err.Error(), "Public access is not permitted on this storage account")
+	require.Contains(t, err.Error(), "Service request ID")
 }
 
 func Test_blobAppend_actualBlob(t *testing.T) {

--- a/pkg/download/blobwithmsitoken_test.go
+++ b/pkg/download/blobwithmsitoken_test.go
@@ -3,6 +3,7 @@ package download
 import (
 	"encoding/json"
 	"io/ioutil"
+	"net/http"
 	"testing"
 
 	"github.com/Azure/azure-extension-foundation/msi"
@@ -45,13 +46,30 @@ func Test_realDownloadBlobWithMsiToken(t *testing.T) {
 		err := json.Unmarshal([]byte(msiJson), &msi)
 		return msi, err
 	}}
-	_, stream, err := Download(&downloader)
+	_, stream, err := Download(testctx, &downloader)
 	require.NoError(t, err, "File download failed")
 	defer stream.Close()
 
 	bytes, err := ioutil.ReadAll(stream)
 	require.NoError(t, err, "saving file stream to memory failed")
 	require.Contains(t, string(bytes), stringToLookFor)
+}
+
+func Test_realDownloadBlobWithMsiToken404(t *testing.T) {
+	if msiJson == "" || blobUri == "" || stringToLookFor == "" {
+		t.Skip()
+	}
+	var badBlobUri = blobUri[0 : len(blobUri)-1]
+	downloader := blobWithMsiToken{badBlobUri, func() (msi.Msi, error) {
+		msi := msi.Msi{}
+		err := json.Unmarshal([]byte(msiJson), &msi)
+		return msi, err
+	}}
+	code, _, err := Download(testctx, &downloader)
+	require.NotNil(t, err, "File download succeeded but was not supposed to")
+	require.Equal(t, http.StatusNotFound, code)
+	require.Contains(t, err.Error(), MsiDownload404ErrorString)
+	require.Contains(t, err.Error(), "Service request ID:") // should have a service request ID since downloading from Azure Storage
 }
 
 func Test_isAzureStorageBlobUri(t *testing.T) {

--- a/pkg/download/downloader.go
+++ b/pkg/download/downloader.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Azure/run-command-handler-linux/pkg/urlutil"
+	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 )
 
@@ -45,12 +46,15 @@ var (
 // Download retrieves a response body and checks the response status code to see
 // if it is 200 OK and then returns the response body. It issues a new request
 // every time called. It is caller's responsibility to close the response body.
-func Download(downloader Downloader) (int, io.ReadCloser, error) {
+func Download(ctx *log.Context, downloader Downloader) (int, io.ReadCloser, error) {
 	request, err := downloader.GetRequest()
 	if err != nil {
 		return -1, nil, errors.Wrapf(err, "failed to create http request")
 	}
-
+	requestID := request.Header.Get(xMsClientRequestIdHeaderName)
+	if len(requestID) > 0 {
+		ctx.Log("info", fmt.Sprintf("starting download with client request ID %s", requestID))
+	}
 	response, err := httpClient.Do(request)
 	if err != nil {
 		err = urlutil.RemoveUrlFromErr(err)
@@ -61,7 +65,8 @@ func Download(downloader Downloader) (int, io.ReadCloser, error) {
 		return response.StatusCode, response.Body, nil
 	}
 
-	err = fmt.Errorf("Status code %d while downloading blob '%s'. Use either a public script URI that points to .sh file, Azure storage blob SAS URI or storage blob accessible by a managed identity and retry. For more info, refer https://aka.ms/RunCommandManagedLinux", response.StatusCode, request.URL.Opaque)
+	errString := ""
+	requestId := response.Header.Get(xMsServiceRequestIdHeaderName)
 	switch downloader.(type) {
 	case *blobWithMsiToken:
 		switch response.StatusCode {
@@ -75,6 +80,34 @@ func Download(downloader Downloader) (int, io.ReadCloser, error) {
 			forbiddenError := fmt.Errorf("Make sure managed identity has been given access to container of storage blob '%s' with 'Storage Blob Data Reader' role assignment. In case of user assigned identity, make sure you add it under VM's identity. For more info, refer https://aka.ms/RunCommandManagedLinux", request.URL.Opaque)
 			return response.StatusCode, nil, errors.Wrapf(forbiddenError, MsiDownload403ErrorString)
 		}
+	default:
+		hostname := request.URL.Host 
+		switch response.StatusCode {
+		case http.StatusUnauthorized:
+			errString = fmt.Sprintf("RunCommand failed to download the file from %s because access was denied. Please fix the blob permissions and try again, the response code and message returned were: %q",
+				hostname,
+				response.Status)
+		case http.StatusNotFound:
+			errString = fmt.Sprintf("RunCommand failed to download the file from %s because it does not exist. Please create the blob and try again, the response code and message returned were: %q",
+				hostname,
+				response.Status)
+
+		case http.StatusBadRequest:
+			errString = fmt.Sprintf("RunCommand failed to download the file from %s because parts of the request were incorrectly formatted, missing, and/or invalid. The response code and message returned were: %q",
+				hostname,
+				response.Status)
+
+		case http.StatusInternalServerError:
+			errString = fmt.Sprintf("RunCommand failed to download the file from %s due to an issue with storage. The response code and message returned were: %q",
+				hostname,
+				response.Status)
+		default:
+			errString = fmt.Sprintf("RunCommand failed to download the file from %s because the server returned a response code and message of %q Please verify the machine has network connectivity.",
+				hostname,
+				response.Status)
 	}
-	return response.StatusCode, nil, err
+	if len(requestId) > 0 {
+		errString += fmt.Sprintf(" (Service request ID: %s)", requestId)
+	}
+	return response.StatusCode, nil, fmt.Errorf(errString)
 }

--- a/pkg/download/downloader_test.go
+++ b/pkg/download/downloader_test.go
@@ -13,10 +13,15 @@ import (
 
 	"github.com/Azure/run-command-handler-linux/pkg/download"
 	"github.com/ahmetalpbalkan/go-httpbin"
+	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/require"
 )
 
 type badDownloader struct{ calls int }
+
+var (
+	testctx = log.NewContext(log.NewNopLogger())
+)
 
 func (b *badDownloader) GetRequest() (*http.Request, error) {
 	b.calls++
@@ -24,18 +29,18 @@ func (b *badDownloader) GetRequest() (*http.Request, error) {
 }
 
 func TestDownload_wrapsGetRequestError(t *testing.T) {
-	_, _, err := download.Download(new(badDownloader))
+	_, _, err := download.Download(testctx, new(badDownloader))
 	require.NotNil(t, err)
 	require.EqualError(t, err, "failed to create http request: expected error")
 }
 
 func TestDownload_wrapsHTTPError(t *testing.T) {
-	_, _, err := download.Download(download.NewURLDownload("bad url"))
+	_, _, err := download.Download(testctx, download.NewURLDownload("bad url"))
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "http request failed:")
 }
 
-func TestDownload_badStatusCodeFails(t *testing.T) {
+func TestDownload_wrapsCommonErrorCodes(t *testing.T) {
 	srv := httptest.NewServer(httpbin.GetMux())
 	defer srv.Close()
 
@@ -47,9 +52,21 @@ func TestDownload_badStatusCodeFails(t *testing.T) {
 		http.StatusBadRequest,
 		http.StatusUnauthorized,
 	} {
-		_, _, err := download.Download(download.NewURLDownload(fmt.Sprintf("%s/status/%d", srv.URL, code)))
+		respCode, _, err := download.Download(testctx, download.NewURLDownload(fmt.Sprintf("%s/status/%d", srv.URL, code)))
 		require.NotNil(t, err, "not failed for code:%d", code)
-		require.Contains(t, err.Error(), fmt.Sprintf("Status code %d while downloading blob", code))
+		require.Equal(t, code, respCode)
+		switch respCode {
+		case http.StatusNotFound:
+			require.Contains(t, err.Error(), "because it does not exist")
+		case http.StatusForbidden:
+			require.Contains(t, err.Error(), "Please verify the machine has network connectivity")
+		case http.StatusInternalServerError:
+			require.Contains(t, err.Error(), "due to an issue with storage")
+		case http.StatusBadRequest:
+			require.Contains(t, err.Error(), "because parts of the request were incorrectly formatted, missing, and/or invalid")
+		case http.StatusUnauthorized:
+			require.Contains(t, err.Error(), "because access was denied")
+		}
 	}
 }
 
@@ -57,7 +74,7 @@ func TestDownload_statusOKSucceeds(t *testing.T) {
 	srv := httptest.NewServer(httpbin.GetMux())
 	defer srv.Close()
 
-	_, body, err := download.Download(download.NewURLDownload(srv.URL + "/status/200"))
+	_, body, err := download.Download(testctx, download.NewURLDownload(srv.URL+"/status/200"))
 	require.Nil(t, err)
 	defer body.Close()
 	require.NotNil(t, body)
@@ -72,13 +89,13 @@ func TestDowload_msiDownloaderErrorMessage(t *testing.T) {
 
 	msiDownloader404 := download.NewBlobWithMsiDownload(srv.URL+"/status/404", mockMsiProvider)
 
-	returnCode, body, err := download.Download(msiDownloader404)
+	returnCode, body, err := download.Download(testctx, msiDownloader404)
 	require.True(t, strings.Contains(err.Error(), download.MsiDownload404ErrorString), "error string doesn't contain the correct message")
 	require.Nil(t, body, "body is not nil for failed download")
 	require.Equal(t, 404, returnCode, "return code was not 404")
 
 	msiDownloader403 := download.NewBlobWithMsiDownload(srv.URL+"/status/403", mockMsiProvider)
-	returnCode, body, err = download.Download(msiDownloader403)
+	returnCode, body, err = download.Download(testctx, msiDownloader403)
 	require.True(t, strings.Contains(err.Error(), download.MsiDownload403ErrorString), "error string doesn't contain the correct message")
 	require.Nil(t, body, "body is not nil for failed download")
 	require.Equal(t, 403, returnCode, "return code was not 403")
@@ -89,7 +106,7 @@ func TestDownload_retrievesBody(t *testing.T) {
 	srv := httptest.NewServer(httpbin.GetMux())
 	defer srv.Close()
 
-	_, body, err := download.Download(download.NewURLDownload(srv.URL + "/bytes/65536"))
+	_, body, err := download.Download(testctx, download.NewURLDownload(srv.URL+"/bytes/65536"))
 	require.Nil(t, err)
 	defer body.Close()
 	b, err := ioutil.ReadAll(body)
@@ -101,7 +118,7 @@ func TestDownload_bodyClosesWithoutError(t *testing.T) {
 	srv := httptest.NewServer(httpbin.GetMux())
 	defer srv.Close()
 
-	_, body, err := download.Download(download.NewURLDownload(srv.URL + "/get"))
+	_, body, err := download.Download(testctx, download.NewURLDownload(srv.URL+"/get"))
 	require.Nil(t, err)
 	require.Nil(t, body.Close(), "body should close fine")
 }

--- a/pkg/download/retry.go
+++ b/pkg/download/retry.go
@@ -37,7 +37,7 @@ func WithRetries(ctx *log.Context, downloaders []Downloader, sf SleepFunc) (io.R
 	for _, d := range downloaders {
 		for n := 0; n < expRetryN; n++ {
 			ctx := ctx.With("retry", n)
-			status, out, err := Download(d)
+			status, out, err := Download(ctx, d)
 			if err == nil {
 				return out, nil
 			}

--- a/pkg/download/retry_test.go
+++ b/pkg/download/retry_test.go
@@ -60,7 +60,8 @@ func TestWithRetries_failingBadStatusCode_validateSleeps(t *testing.T) {
 
 	sr := new(sleepRecorder)
 	_, err := download.WithRetries(nopLog(), []download.Downloader{d}, sr.Sleep)
-	require.Contains(t, err.Error(), "Status code 429 while downloading blob")
+	require.Contains(t, err.Error(), "429 Too Many Requests")
+	require.Contains(t, err.Error(), "Please verify the machine has network connectivity")
 
 	require.Equal(t, sleepSchedule, []time.Duration(*sr))
 }

--- a/pkg/download/url.go
+++ b/pkg/download/url.go
@@ -1,8 +1,14 @@
 package download
 
 import (
+	"github.com/google/uuid"
 	"net/http"
 	"net/url"
+)
+
+const (
+	xMsClientRequestIdHeaderName  = "x-ms-client-request-id"
+	xMsServiceRequestIdHeaderName = "x-ms-request-id"
 )
 
 // urlDownload describes a URL to download.
@@ -17,7 +23,11 @@ func NewURLDownload(url string) Downloader {
 
 // GetRequest returns a new request to download the URL
 func (u urlDownload) GetRequest() (*http.Request, error) {
-	return http.NewRequest("GET", u.url, nil)
+	req, err := http.NewRequest("GET", u.url, nil)
+	if req != nil {
+		req.Header.Add(xMsClientRequestIdHeaderName, uuid.New().String())
+	}
+	return req, err
 }
 
 // Scrub query. Used to remove the query parts like SAS token.

--- a/pkg/download/url_test.go
+++ b/pkg/download/url_test.go
@@ -25,6 +25,7 @@ func Test_urlDownload_GetRequest_goodURL(t *testing.T) {
 	r, err := d.GetRequest()
 	require.Nil(t, err, u)
 	require.NotNil(t, r, u)
+	require.NotNil(t, r.Header.Get(xMsClientRequestIdHeaderName))
 }
 
 func Test_GetUriForLogging_ScrubsQuery(t *testing.T) {

--- a/vendor/github.com/google/uuid/go.mod
+++ b/vendor/github.com/google/uuid/go.mod
@@ -1,0 +1,1 @@
+module github.com/google/uuid

--- a/vendor/github.com/google/uuid/hash.go
+++ b/vendor/github.com/google/uuid/hash.go
@@ -39,7 +39,7 @@ func NewHash(h hash.Hash, space UUID, data []byte, version int) UUID {
 // NewMD5 returns a new MD5 (Version 3) UUID based on the
 // supplied name space and data.  It is the same as calling:
 //
-//  NewHash(md5.New(), space, data, 3)
+//	NewHash(md5.New(), space, data, 3)
 func NewMD5(space UUID, data []byte) UUID {
 	return NewHash(md5.New(), space, data, 3)
 }
@@ -47,7 +47,7 @@ func NewMD5(space UUID, data []byte) UUID {
 // NewSHA1 returns a new SHA1 (Version 5) UUID based on the
 // supplied name space and data.  It is the same as calling:
 //
-//  NewHash(sha1.New(), space, data, 5)
+//	NewHash(sha1.New(), space, data, 5)
 func NewSHA1(space UUID, data []byte) UUID {
 	return NewHash(sha1.New(), space, data, 5)
 }

--- a/vendor/github.com/google/uuid/null.go
+++ b/vendor/github.com/google/uuid/null.go
@@ -1,0 +1,118 @@
+// Copyright 2021 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uuid
+
+import (
+	"bytes"
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
+
+var jsonNull = []byte("null")
+
+// NullUUID represents a UUID that may be null.
+// NullUUID implements the SQL driver.Scanner interface so
+// it can be used as a scan destination:
+//
+//  var u uuid.NullUUID
+//  err := db.QueryRow("SELECT name FROM foo WHERE id=?", id).Scan(&u)
+//  ...
+//  if u.Valid {
+//     // use u.UUID
+//  } else {
+//     // NULL value
+//  }
+//
+type NullUUID struct {
+	UUID  UUID
+	Valid bool // Valid is true if UUID is not NULL
+}
+
+// Scan implements the SQL driver.Scanner interface.
+func (nu *NullUUID) Scan(value interface{}) error {
+	if value == nil {
+		nu.UUID, nu.Valid = Nil, false
+		return nil
+	}
+
+	err := nu.UUID.Scan(value)
+	if err != nil {
+		nu.Valid = false
+		return err
+	}
+
+	nu.Valid = true
+	return nil
+}
+
+// Value implements the driver Valuer interface.
+func (nu NullUUID) Value() (driver.Value, error) {
+	if !nu.Valid {
+		return nil, nil
+	}
+	// Delegate to UUID Value function
+	return nu.UUID.Value()
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (nu NullUUID) MarshalBinary() ([]byte, error) {
+	if nu.Valid {
+		return nu.UUID[:], nil
+	}
+
+	return []byte(nil), nil
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (nu *NullUUID) UnmarshalBinary(data []byte) error {
+	if len(data) != 16 {
+		return fmt.Errorf("invalid UUID (got %d bytes)", len(data))
+	}
+	copy(nu.UUID[:], data)
+	nu.Valid = true
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (nu NullUUID) MarshalText() ([]byte, error) {
+	if nu.Valid {
+		return nu.UUID.MarshalText()
+	}
+
+	return jsonNull, nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (nu *NullUUID) UnmarshalText(data []byte) error {
+	id, err := ParseBytes(data)
+	if err != nil {
+		nu.Valid = false
+		return err
+	}
+	nu.UUID = id
+	nu.Valid = true
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler.
+func (nu NullUUID) MarshalJSON() ([]byte, error) {
+	if nu.Valid {
+		return json.Marshal(nu.UUID)
+	}
+
+	return jsonNull, nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (nu *NullUUID) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(data, jsonNull) {
+		*nu = NullUUID{}
+		return nil // valid null UUID
+	}
+	err := json.Unmarshal(data, &nu.UUID)
+	nu.Valid = err == nil
+	return err
+}


### PR DESCRIPTION
For [Error Improvements in VM Extensions](https://microsoft.sharepoint.com/:w:/t/ComputeVM/ERQYqh3QTktFrdtAgBMZvAgBLKT8DqKH3K0rKznDVCr11A?e=bJE1Zm) , when downloading scripts we will log the request ID, response ID, and response code (if provided) and give specific error messages for status codes 401, 404, 400, 500.