### PR TITLE
Change Architecture variable in shim file to be consistent with RCv1, CSE

### DIFF
--- a/misc/run-command-shim
+++ b/misc/run-command-shim
@@ -4,7 +4,7 @@ set -e -o pipefail
 readonly SCRIPT_DIR=$(dirname "$0")
 readonly LOG_DIR="/var/log/azure/run-command-handler"
 readonly LOG_FILE=handler.log
-readonly ARCHITECTURE=$(uname -p)
+readonly ARCHITECTURE=$( [[ "$(uname -p)" == "unknown" ]] && echo "$(uname -m)" || echo "$(uname -p)" ) #ternary operator
 HANDLER_BIN="run-command-handler"
 if [ $ARCHITECTURE == "arm64" ] || [ $ARCHITECTURE == "aarch64" ]; then
      HANDLER_BIN="run-command-handler-arm64";


### PR DESCRIPTION
- This is needed for enabling Run Command v2 for ARM64 VMs