### PR TITLE
RunCommandv2 Linux - Add treatFailureAsDeploymentFailure flag

### DIFF
--- a/main/cmds.go
+++ b/main/cmds.go
@@ -116,12 +116,7 @@ func min(a, b int) int {
 
 func enable(ctx *log.Context, h HandlerEnvironment, report *RunCommandInstanceView, extName string, seqNum int) (string, string, error) {
 	// parse the extension handler settings (not available prior to 'enable')
-	configFile := fmt.Sprintf("%d.settings", seqNum)
-	if extName != "" {
-		configFile = extName + "." + configFile
-	}
-	configPath := filepath.Join(h.HandlerEnvironment.ConfigFolder, configFile)
-	cfg, err := parseAndValidateSettings(ctx, configPath)
+	cfg, err := GetHandlerSettings(h.HandlerEnvironment.ConfigFolder, extName, seqNum, ctx)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to get configuration")
 	}

--- a/main/handlersettings.go
+++ b/main/handlersettings.go
@@ -42,13 +42,14 @@ func (s handlerSettings) validate() error {
 // publicSettings is the type deserialized from public configuration section of
 // the extension handler. This should be in sync with publicSettingsSchema.
 type publicSettings struct {
-	Source           *scriptSource         `json:"source"`
-	Parameters       []parameterDefinition `json:"parameters"`
-	RunAsUser        string                `json:"runAsUser"`
-	OutputBlobURI    string                `json:"outputBlobUri"`
-	ErrorBlobURI     string                `json:"errorBlobUri"`
-	TimeoutInSeconds int                   `json:"timeoutInSeconds,int"`
-	AsyncExecution   bool                  `json:"asyncExecution,bool"`
+	Source                          *scriptSource         `json:"source"`
+	Parameters                      []parameterDefinition `json:"parameters"`
+	RunAsUser                       string                `json:"runAsUser"`
+	OutputBlobURI                   string                `json:"outputBlobUri"`
+	ErrorBlobURI                    string                `json:"errorBlobUri"`
+	TimeoutInSeconds                int                   `json:"timeoutInSeconds,int"`
+	AsyncExecution                  bool                  `json:"asyncExecution,bool"`
+	TreatFailureAsDeploymentFailure bool                  `json:"treatFailureAsDeploymentFailure,bool"`
 }
 
 // protectedSettings is the type decoded and deserialized from protected

--- a/main/main.go
+++ b/main/main.go
@@ -124,7 +124,15 @@ func main() {
 		instanceView.ExitCode = -1
 		instanceView.EndTime = time.Now().UTC().Format(time.RFC3339)
 		instanceView.ExitCode = cmd.failExitCode
-		reportInstanceView(ctx, hEnv, extensionName, seqNum, StatusSuccess, cmd, &instanceView)
+		statusToReport := StatusSuccess
+
+		// If TreatFailureAsDeploymentFailure is set, report error back as the status
+		cfg, err := GetHandlerSettings(hEnv.HandlerEnvironment.ConfigFolder, extensionName, seqNum, ctx)
+		if err == nil && cfg.publicSettings.TreatFailureAsDeploymentFailure {
+			statusToReport = StatusError
+		}
+
+		reportInstanceView(ctx, hEnv, extensionName, seqNum, statusToReport, cmd, &instanceView)
 		os.Exit(cmd.failExitCode)
 	} else { // No error. succeeded
 		instanceView.ExecutionMessage = "Execution completed"

--- a/main/utilities.go
+++ b/main/utilities.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
+
+	"github.com/go-kit/kit/log"
 )
 
 func DoesFileExist(path string) bool {
@@ -28,4 +32,15 @@ func GetUriForLogging(uriString string) string {
 	}
 
 	return u.Scheme + "//" + u.Host + u.Path
+}
+
+// Get handler settings from config folder. Example path: /var/lib/waagent/Microsoft.CPlat.Core.RunCommandHandlerLinux-1.3.2/config
+func GetHandlerSettings(configFolder string, extensionName string, sequenceNumber int, logContext *log.Context) (handlerSettings, error) {
+	configFile := fmt.Sprintf("%d.settings", sequenceNumber)
+	if extensionName != "" {
+		configFile = extensionName + "." + configFile
+	}
+	configPath := filepath.Join(configFolder, configFile)
+	cfg, err := parseAndValidateSettings(logContext, configPath)
+	return cfg, err
 }


### PR DESCRIPTION
- If user passes treatFailureAsDeploymentFailure as true, set the extension status to error if there is an error message or process returns non-zero exit code so that CRP provisioningState is set to Failed. This helps users with easier surfacing of failures.
- The CRP call RunCommand.PUT would end with a 201 - ClientError that would have the error message