### PR TITLE
Do not write status file under root directory at the start of RC execution

### DIFF
--- a/misc/run-command-shim
+++ b/misc/run-command-shim
@@ -18,29 +18,6 @@ echo "ConfigSequenceNumber: $SEQNO"
 echo Architecture: $ARCHITECTURE
 echo Binary: $HANDLER_BIN
 
-# status_file returns the .status file path we are supposed to write
-# by determining the highest sequence number from ./config/*.settings files.
-status_file_path() {
-        # multiconfig support: status file name should be "extname.seqNo.status"
-        if [ -n "$EXTENSION_NAME" ] && [ -n "$ConfigSequenceNumber" ]; then
-            status_file=$(echo $EXTENSION_NAME.$SEQNO.status)
-        else
-            # normally we would need to find this config_dir by parsing the
-            # HandlerEnvironment.json, but we are in a bash script here,
-            # so assume it's at ../config/.
-            config_dir=$(readlink -f "${SCRIPT_DIR}/../config")
-            status_dir=$(readlink -f "${SCRIPT_DIR}/../status")
-            config_file=$(ls $config_dir | grep -E ^[0-9]+.settings$ | sort -n | tail -n 1)
-            if [ -f "$config_file" ]; then
-                echo "Cannot locate the config file.">&2
-                exit 1
-            fi
-            status_file=$(echo $config_file | sed s/settings/status/)
-        fi
-
-        readlink -f "$status_dir/$status_file"
-}
-
 check_binary_write_lock() {
     set +e # disable exit on non-zero return code
     local retry_attempts=0

--- a/misc/run-command-shim
+++ b/misc/run-command-shim
@@ -41,32 +41,6 @@ status_file_path() {
         readlink -f "$status_dir/$status_file"
 }
 
-write_status() {
-	status_file="$(status_file_path)"
-	if [ -f "$status_file" ]; then
-		echo "Not writing a placeholder status file, already exists: $status_file"
-	else
-		echo "Writing a placeholder status file indicating progress before forking: $status_file"
-		timestamp="$(date --utc --iso-8601=seconds)"
-		cat > "$status_file" <<- EOF
-			[
-				{
-					"version": 1,
-					"timestampUTC": "$timestamp",
-					"status": {
-						"operation": "Enable",
-						"status": "transitioning",
-						"formattedMessage": {
-							"lang": "en",
-							"message": "{}"
-						}
-					}
-				}
-			]
-		EOF
-	fi
-}
-
 check_binary_write_lock() {
     set +e # disable exit on non-zero return code
     local retry_attempts=0
@@ -124,10 +98,9 @@ bin="$(readlink -f "$SCRIPT_DIR/$HANDLER_BIN")"
 cmd="$1"
 
 if [[ "$cmd" == "enable" ]]; then
-    # for 'enable' command, write a .status file first, then double fork
+    # for 'enable' command, double fork
     # to detach from the handler process tree to avoid getting terminated 
     # after the 15-minute extension enabling timeout.
-    write_status
     check_binary_write_lock
     set -x
     # & will execute the binary on the backgraound and will not block current shell execution


### PR DESCRIPTION
- Seems status file was a placeholder for testing. Removed it
- Reported in
[Incident 415855657](https://portal.microsofticm.com/imp/v3/incidents/incident/415855657/summary) : RunCommandHandlerLinux extension creates  '/commandId.sequence.status' files in the root path of file system
[Incident 406289615](https://portal.microsofticm.com/imp/v3/incidents/incident/406289615/summary) : Linux Runcommand ARC for servers Creates .status files in root directory.
- Task [Bug 24849045](https://msazure.visualstudio.com/One/_workitems/edit/24849045): Linux Runcommand for servers Creates .status files in root directory.
- Tested by replacing the run-command-shim file on an Azure VM