### PR TITLE
Adds support for extra artifact downloads to Linux RCV2

### DIFF
--- a/main/cmds_test.go
+++ b/main/cmds_test.go
@@ -142,6 +142,97 @@ func Test_downloadScriptUri(t *testing.T) {
 	require.Nil(t, err, "%s is missing from download dir", fp)
 }
 
+func Test_downloadArtifacts_Invalid(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	srv := httptest.NewServer(httpbin.GetMux())
+	defer srv.Close()
+
+	// The count of public vs protected settings differs
+	err = downloadArtifacts(log.NewContext(log.NewNopLogger()),
+		dir,
+		&handlerSettings{
+			publicSettings: publicSettings{
+				Source: &scriptSource{ScriptURI: srv.URL + "/bytes/10"},
+				Artifacts: []publicArtifactSource{
+					publicArtifactSource{
+						ArtifactId:  1,
+						ArtifactUri: srv.URL + "/status/404",
+						FileName:    "flipper",
+					},
+				},
+			},
+			protectedSettings: protectedSettings{
+				Artifacts: []protectedArtifactSource{},
+			},
+		})
+
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "RunCommand artifact download failed. Reason: Invalid artifact specification. This is a product bug.")
+
+	// ArtifactIds don't match
+	err = downloadArtifacts(log.NewContext(log.NewNopLogger()),
+		dir,
+		&handlerSettings{
+			publicSettings: publicSettings{
+				Source: &scriptSource{ScriptURI: srv.URL + "/bytes/10"},
+				Artifacts: []publicArtifactSource{
+					publicArtifactSource{
+						ArtifactId:  1,
+						ArtifactUri: srv.URL + "/status/404",
+						FileName:    "flipper",
+					},
+				},
+			},
+			protectedSettings: protectedSettings{
+				Artifacts: []protectedArtifactSource{
+					protectedArtifactSource{
+						ArtifactId: 2,
+					},
+				},
+			},
+		})
+
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "RunCommand artifact download failed. Reason: Invalid artifact specification. This is a product bug.")
+}
+
+func Test_downloadArtifactsFail(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	srv := httptest.NewServer(httpbin.GetMux())
+	defer srv.Close()
+
+	err = downloadArtifacts(log.NewContext(log.NewNopLogger()),
+		dir,
+		&handlerSettings{
+			publicSettings: publicSettings{
+				Source: &scriptSource{ScriptURI: srv.URL + "/bytes/10"},
+				Artifacts: []publicArtifactSource{
+					publicArtifactSource{
+						ArtifactId:  1,
+						ArtifactUri: srv.URL + "/status/404",
+						FileName:    "flipper",
+					},
+				},
+			},
+			protectedSettings: protectedSettings{
+				Artifacts: []protectedArtifactSource{
+					protectedArtifactSource{
+						ArtifactId: 1,
+					},
+				},
+			},
+		})
+
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "failed to download artifact")
+}
+
 func Test_downloadArtifacts(t *testing.T) {
 	dir, err := ioutil.TempDir("", "")
 	require.Nil(t, err)
@@ -241,7 +332,8 @@ func Test_downloadScriptUri_BySASFailsSucceedsByManagedIdentity(t *testing.T) {
 
 // This test just makes sure using TreatFailureAsDeploymentFailure flag, script is executed as expected.
 // The interpretation of the result (Succeeded or Failed, when TreatFailureAsDeploymentFailure is true)
-//     is done in main.go
+//
+//	is done in main.go
 func Test_TreatFailureAsDeploymentFailureIsTrue_Fails(t *testing.T) {
 	var script = "ech HelloWorld" // ech is an unknown command. Sh returns error and 127 status code
 	dir, err := ioutil.TempDir("", "")
@@ -258,7 +350,8 @@ func Test_TreatFailureAsDeploymentFailureIsTrue_Fails(t *testing.T) {
 
 // This test just makes sure using TreatFailureAsDeploymentFailure flag, script is executed as expected.
 // The interpretation of the result (Succeeded or Failed, when TreatFailureAsDeploymentFailure is true)
-//     is done in main.go
+//
+//	is done in main.go
 func Test_TreatFailureAsDeploymentFailureIsTrue_SimpleScriptSucceeds(t *testing.T) {
 	var script = "echo HelloWorld" // ech is an unknown command. Sh returns error and 127 status code
 	dir, err := ioutil.TempDir("", "")

--- a/main/files.go
+++ b/main/files.go
@@ -18,21 +18,39 @@ import (
 
 var UseMockSASDownloadFailure bool = false
 
-// downloadAndProcessURL downloads using the specified downloader and saves it to the
-// specified existing directory, which must be the path to the saved file. Then
-// it post-processes file based on heuristics.
-func downloadAndProcessURL(ctx *log.Context, url, downloadDir string, cfg *handlerSettings) (string, error) {
+func downloadAndProcessArtifact(ctx *log.Context, downloadDir string, artifact *unifiedArtifact) (string, error) {
+	fileName := artifact.FileName
+	if fileName == "" {
+		fileName = fmt.Sprintf("%s%d", artifact.ArtifactId, "Artifact")
+	}
+	targetFilePath, err := downloadAndProcessURL(ctx, artifact.ArtifactUri, downloadDir, fileName, artifact.ArtifactSasToken, artifact.ArtifactManagedIdentity)
+
+	return targetFilePath, err
+}
+
+func downloadAndProcessScript(ctx *log.Context, url, downloadDir string, cfg *handlerSettings) (string, error) {
 	fileName, err := urlToFileName(url)
 	if err != nil {
 		return "", err
 	}
 
+	scriptSAS := cfg.scriptSAS()
+	sourceManagedIdentity := cfg.SourceManagedIdentity
+	targetFilePath, err := downloadAndProcessURL(ctx, url, downloadDir, fileName, scriptSAS, sourceManagedIdentity)
+
+	return targetFilePath, err
+}
+
+// downloadAndProcessURL downloads using the specified downloader and saves it to the
+// specified existing directory, which must be the path to the saved file. Then
+// it post-processes file based on heuristics.
+func downloadAndProcessURL(ctx *log.Context, url, downloadDir string, fileName string, scriptSAS string, sourceManagedIdentity *RunCommandManagedIdentity) (string, error) {
+	var err error
 	if !urlutil.IsValidUrl(url) {
 		return "", fmt.Errorf(url + " is not a valid url") // url does not contain SAS to se can log it
 	}
 
 	targetFilePath := filepath.Join(downloadDir, fileName)
-	scriptSAS := cfg.scriptSAS()
 
 	var scriptSASDownloadErr error = nil
 	var downloadedFilePath string = ""
@@ -50,7 +68,7 @@ func downloadAndProcessURL(ctx *log.Context, url, downloadDir string, cfg *handl
 
 	//If there was an error downloading using SAS URI or SAS was not provided, download using managedIdentity or publicly.
 	if scriptSASDownloadErr != nil || scriptSAS == "" {
-		downloaders, getDownloadersError := getDownloaders(url, cfg.SourceManagedIdentity, download.ProdMsiDownloader{})
+		downloaders, getDownloadersError := getDownloaders(url, sourceManagedIdentity, download.ProdMsiDownloader{})
 		if getDownloadersError == nil {
 			const mode = 0500 // we assume users download scripts to execute
 			_, err = download.SaveTo(ctx, downloaders, targetFilePath, mode)

--- a/main/files.go
+++ b/main/files.go
@@ -21,7 +21,7 @@ var UseMockSASDownloadFailure bool = false
 func downloadAndProcessArtifact(ctx *log.Context, downloadDir string, artifact *unifiedArtifact) (string, error) {
 	fileName := artifact.FileName
 	if fileName == "" {
-		fileName = fmt.Sprintf("%s%d", artifact.ArtifactId, "Artifact")
+		fileName = fmt.Sprintf("%s%d", "Artifact", artifact.ArtifactId)
 	}
 	targetFilePath, err := downloadAndProcessURL(ctx, artifact.ArtifactUri, downloadDir, fileName, artifact.ArtifactSasToken, artifact.ArtifactManagedIdentity)
 


### PR DESCRIPTION
Supports downloading extra artifacts in Windows RunCommand V2

We're adding the ability to download up to five extra artifacts before running a script. These may be downloaded via public URI, SAS, or managed identity. The settings are split between public and protected settings.

This mirrors the same changes for Windows RCV2 - https://msazure.visualstudio.com/One/_git/Compute-ART-Extensions/pullrequest/9217625