### PR TITLE
Improved instanceView output and error handling when command invocation fails.

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -117,6 +117,9 @@ func main() {
 
 	// execute the subcommand
 	stdout, stderr, cmdInvokeError, exitCode := cmd.invoke(ctx, hEnv, &instanceView, extensionName, seqNum)
+	
+	instanceView.Output = stdout
+	instanceView.Error = stderr
 	if cmdInvokeError != nil {
 		ctx.Log("event", "failed to handle", "error", cmdInvokeError)
 		instanceView.ExecutionMessage = "Execution failed: " + cmdInvokeError.Error()
@@ -140,8 +143,6 @@ func main() {
 		instanceView.ExitCode = ExitCode_Okay
 	}
 
-	instanceView.Output = stdout
-	instanceView.Error = stderr
 	reportInstanceView(ctx, hEnv, extensionName, seqNum, StatusSuccess, cmd, &instanceView)
 	ctx.Log("event", "end")
 }


### PR DESCRIPTION
This pull request includes changes to the `main/main.go` file, specifically within the `func main() {}` function. The changes involve the reordering of code lines to assign `stdout` and `stderr` to `instanceView.Output` and `instanceView.Error` respectively, before the error handling block. This allows the output and error to be logged even if the command invocation fails.

Here are the key changes:

* [`main/main.go`](diffhunk://#diff-327181d0a8c5e6b164561d7910f4eeffd41442d55b2a2788fda2aa2692f17ec0R120-R122): Moved the assignment of `stdout` and `stderr` to `instanceView.Output` and `instanceView.Error` respectively, to occur before the error handling block. This ensures that the output and error are logged even if an error occurs during command invocation. [[1]](diffhunk://#diff-327181d0a8c5e6b164561d7910f4eeffd41442d55b2a2788fda2aa2692f17ec0R120-R122) [[2]](diffhunk://#diff-327181d0a8c5e6b164561d7910f4eeffd41442d55b2a2788fda2aa2692f17ec0L143-L144)
