### PR TITLE
Copy .status status files during update so that status of previously executed extensions are returned

### DIFF
--- a/internal/cmds/cmds.go
+++ b/internal/cmds/cmds.go
@@ -73,10 +73,10 @@ func update(ctx *log.Context, h types.HandlerEnvironment, report *types.RunComma
 	}
 
 	// Copy any .mrseq or .status files -Most Recently executed Sequence number files and status files for Run Commands from old version to new version.
-	// This is necessary to prevent rerunning of already executed Run Commands after upgrade of extension version.
+	// This is necessary to prevent rerunning of already executed Run Commands after upgrade of extension version, and also return their statuses.
 	copyError := CopyStateForUpdate(ctx)
 	if copyError != nil {
-		return "", "", errors.New("Migrating *.mrseq or .status files failed during update."), constants.ExitCode_CopyingMreSequenceFilesFailed
+		return "", "", errors.Wrap(copyError, "Migrating *.mrseq or .status files failed during update."), constants.ExitCode_CopyStateForUpdateFailed
 	}
 
 	ctx.Log("event", "update")

--- a/internal/cmds/cmds.go
+++ b/internal/cmds/cmds.go
@@ -377,6 +377,7 @@ func copyMrseqFiles(ctx log.Logger) (error) {
 				ctx.Log("message", fmt.Sprintf(errMessage, sourceFileFullPath))
 				return errors.Wrapf(sourceFileOpenError, errMessage)
 			}
+			defer sourceFile.Close()
 
 			destFile, destFileCreateError := os.Create(destinationFileFullPath)
 			if destFileCreateError != nil {
@@ -384,6 +385,7 @@ func copyMrseqFiles(ctx log.Logger) (error) {
 				ctx.Log("message", fmt.Sprintf(errMessage, destFile))
 				return errors.Wrapf(destFileCreateError, errMessage)
 			}
+			defer destFile.Close()
 
 			_, copyError := io.Copy(destFile, sourceFile)
 			if copyError != nil {
@@ -393,10 +395,7 @@ func copyMrseqFiles(ctx log.Logger) (error) {
 			} else {
 				ctx.Log("message", fmt.Sprintf("File '%s' was copied successfully to '%s'", sourceFileFullPath, destinationFileFullPath))
 				numberOfFilesMigrated++
-			}
-			 
-			sourceFile.Close()
-			destFile.Close()
+			}		 
 		}
 	}
 

--- a/internal/cmds/cmds.go
+++ b/internal/cmds/cmds.go
@@ -371,7 +371,7 @@ func copyMrseqFiles(ctx log.Logger) (error) {
 			sourceFileFullPath := filepath.Join(oldExtensionDirectory, fileName)
 			destinationFileFullPath := filepath.Join(newExtensionDirectory, fileName)
 
-			sourceFile, sourceFileOpenError := os.OpenFile(sourceFileFullPath, os.O_RDONLY, 0400)
+			sourceFile, sourceFileOpenError := os.Open(sourceFileFullPath)
 			if sourceFileOpenError != nil {
 				errMessage := "Failed to open .mrseq file '%s' for reading. Contact ICM team AzureRT\\Extensions for this service error."
 				ctx.Log("message", fmt.Sprintf(errMessage, sourceFileFullPath))

--- a/internal/cmds/cmds_test.go
+++ b/internal/cmds/cmds_test.go
@@ -18,6 +18,56 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_CopyMrseqFiles_MrseqFilesAreCopied(t *testing.T) {
+	currentExtensionVersionDirectory := "Microsoft.CPlat.Core.RunCommandHandlerLinux-1.3.8"
+	os.Setenv(constants.ExtensionPathEnvName, currentExtensionVersionDirectory)
+	os.Setenv(constants.ExtensionVersionUpdatingFromEnvName, "1.3.7")
+	os.Setenv(constants.ExtensionVersionEnvName, "1.3.8")
+	 
+	currentVersion := os.Getenv(constants.ExtensionVersionEnvName)
+	previousVersion := os.Getenv(constants.ExtensionVersionUpdatingFromEnvName)
+	previousExtensionVersionDirectory := strings.ReplaceAll(currentExtensionVersionDirectory, currentVersion, previousVersion)
+
+	// Remove currentExtensionVersionDirectory if it exists
+	_, err := os.Stat(currentExtensionVersionDirectory)
+	if err == nil {
+		os.RemoveAll(currentExtensionVersionDirectory)
+		} 
+
+	// Remove previousExtensionVersionDirectory if it exists
+	_, err = os.Stat(previousExtensionVersionDirectory)
+	if err == nil {
+		os.RemoveAll(previousExtensionVersionDirectory)
+		} 
+
+	// Create previousExtensionVersionDirectory
+	err = os.Mkdir(previousExtensionVersionDirectory, 0777)
+	require.Nil(t, err)
+
+	// Create currentExtensionVersionDirectory
+	err = os.Mkdir(currentExtensionVersionDirectory, 0777)
+	require.Nil(t, err)
+
+	files, _ := ioutil.ReadDir(currentExtensionVersionDirectory)
+    require.Equal(t, 0, len(files))
+
+	os.Create(filepath.Join(previousExtensionVersionDirectory, "1.mrseq"))
+	os.Create(filepath.Join(previousExtensionVersionDirectory, "ABCD.mrseq"))
+	os.Create(filepath.Join(previousExtensionVersionDirectory, "2345.mrseq"))
+	os.Create(filepath.Join(previousExtensionVersionDirectory, "RC0804_0.mrseq"))
+	os.Create(filepath.Join(previousExtensionVersionDirectory, "asdfsad.mrseq"))
+	os.Create(filepath.Join(previousExtensionVersionDirectory, "abc.txt")) // this should not be copied to currentExtensionVersionDirectory
+
+	files, _ = ioutil.ReadDir(currentExtensionVersionDirectory)
+    require.Equal(t, 0, len(files))
+	
+	err = copyMrseqFiles(log.NewContext(log.NewNopLogger()))
+	require.Nil(t, err)
+
+	files, _ = ioutil.ReadDir(currentExtensionVersionDirectory)
+    require.Equal(t, 5, len(files))
+}
+
 func Test_commandsExist(t *testing.T) {
 	// we expect these subcommands to be handled
 	expect := []string{"install", "enable", "disable", "uninstall", "update"}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -40,6 +40,10 @@ const (
 	// See more in: https://github.com/Azure/azure-vmextension-publishing/wiki/2.0-Partner-Guide-Handler-Design-Details#236-summary
 	ExtensionVersionEnvName = "AZURE_GUEST_AGENT_EXTENSION_VERSION"
 
+	// This is the version the extension is updating from
+	// See more in: https://github.com/Azure/azure-vmextension-publishing/wiki/2.0-Partner-Guide-Handler-Design-Details#236-summary
+	ExtensionVersionUpdatingFromEnvName = "AZURE_GUEST_AGENT_UPDATING_FROM_VERSION"
+
 	// The path of the extension in the VM with full name. This value is provided by the agent for all commands.
 	// See more in: https://github.com/Azure/azure-vmextension-publishing/wiki/2.0-Partner-Guide-Handler-Design-Details#236-summary
 	ExtensionPathEnvName = "AZURE_GUEST_AGENT_EXTENSION_PATH"

--- a/internal/constants/exitcodes.go
+++ b/internal/constants/exitcodes.go
@@ -30,7 +30,7 @@ const (
 	ExitCode_InstallServiceFailed                         = -217
 	ExitCode_UninstallInstalledServiceFailed              = -218
 	ExitCode_DisableInstalledServiceFailed                = -219
-	ExitCode_CopyingMreSequenceFilesFailed 			= -220
+	ExitCode_CopyStateForUpdateFailed                     = -220
 
 	// Unknown errors (-300s):
 )

--- a/internal/constants/exitcodes.go
+++ b/internal/constants/exitcodes.go
@@ -30,6 +30,7 @@ const (
 	ExitCode_InstallServiceFailed                         = -217
 	ExitCode_UninstallInstalledServiceFailed              = -218
 	ExitCode_DisableInstalledServiceFailed                = -219
+	ExitCode_CopyingMreSequenceFilesFailed 			= -220
 
 	// Unknown errors (-300s):
 )


### PR DESCRIPTION
Without status files of previously executed Run Commands, new operations would time out as status file wasn't found, but it was already executed using .mrseq file