### PR TITLE
Use success state instead of warning for dummy status during Upgrade

### DIFF
--- a/internal/instanceview/instanceview.go
+++ b/internal/instanceview/instanceview.go
@@ -18,7 +18,7 @@ func ReportInstanceView(ctx *log.Context, hEnv types.HandlerEnvironment, metadat
 		return nil
 	}
 
-	msg, err := serializeInstanceView(instanceview)
+	msg, err := SerializeInstanceView(instanceview)
 	if err != nil {
 		return err
 	}
@@ -26,7 +26,7 @@ func ReportInstanceView(ctx *log.Context, hEnv types.HandlerEnvironment, metadat
 	return c.Functions.ReportStatus(ctx, hEnv, metadata, t, c, msg)
 }
 
-func serializeInstanceView(instanceview *types.RunCommandInstanceView) (string, error) {
+func SerializeInstanceView(instanceview *types.RunCommandInstanceView) (string, error) {
 	bytes, err := instanceview.Marshal()
 	if err != nil {
 		return "", fmt.Errorf("status: failed to marshal into json: %v", err)

--- a/internal/instanceview/instanceview_test.go
+++ b/internal/instanceview/instanceview_test.go
@@ -24,7 +24,7 @@ func Test_serializeInstanceView(t *testing.T) {
 		StartTime:        time.Date(2000, 2, 1, 12, 30, 0, 0, time.UTC).Format(time.RFC3339),
 		EndTime:          time.Date(2000, 2, 1, 12, 35, 0, 0, time.UTC).Format(time.RFC3339),
 	}
-	msg, err := serializeInstanceView(&instanceView)
+	msg, err := SerializeInstanceView(&instanceView)
 	require.Nil(t, err)
 	require.NotNil(t, msg)
 	expectedMsg := "{\"executionState\":\"Running\",\"executionMessage\":\"Completed\",\"output\":\"Script output stream with \\\\ \\n \\t \\\"  \",\"error\":\"Script error stream\",\"exitCode\":0,\"startTime\":\"2000-02-01T12:30:00Z\",\"endTime\":\"2000-02-01T12:35:00Z\"}"
@@ -67,6 +67,6 @@ func Test_reportInstanceView(t *testing.T) {
 	require.Equal(t, types.StatusSuccess, r[0].Status.Status)
 	require.Equal(t, types.CmdEnableTemplate.Name, r[0].Status.Operation)
 
-	msg, _ := serializeInstanceView(&instanceView)
+	msg, _ := SerializeInstanceView(&instanceView)
 	require.Equal(t, msg, r[0].Status.FormattedMessage.Message)
 }

--- a/internal/types/status.go
+++ b/internal/types/status.go
@@ -40,10 +40,6 @@ const (
 
 	// StatusSuccess indicates the operation succeeded
 	StatusSuccess StatusType = "success"
-
-	// StatusWarning indicates the operation was executed, but with one of the below conditions:
-	// 1) Status files have been lost. So, exact execution status (error or success), output and error are not known.
-	StatusWarning StatusType = "warning"
 )
 
 // Status is used for serializing status in a manner the server understands


### PR DESCRIPTION
- Use success state instead of warning for dummy status files during Upgrade, because warning is not a terminal state and it is waited upon for 90 minutes and considered as "Failed" at CRP