### PR TITLE
Fixes disable removing mrseq file

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -25,6 +25,8 @@ const (
 
 	StatusFileDirectory = "status"
 
+	StatusFileExtension = ".status"
+
 	// The directory where the immediate run command status that have reached the terminal status are stored.
 	ImmediateStatusFileDirectory = "status"
 


### PR DESCRIPTION
In version 1.3.17, a bug was introduced that deleted the .mrseq file during the Disable call. This resulted in any upgrade to a new version automatically re-running all previously run traditional scripts.

The simple fix is to change the logic to only delete the .mrseq files for immediate runcommands. In that case, GA is not involved and thus we have to delete them ourselves. Otherwise, GA calls Disable on two occasions:
- When the extension is deleted. In this case, GA already deletes all files for us, so the call is unnecessary.
- During upgrades, where it is called once per extension. Here, we need to NOT delete the .mrseq files, because we need to migrate them during the upgrade step.

A complication occurs though that when we upgrade from 1.3.17 to our next version, we'll wind up re-executing the script because the disable bug is in 1.3.17. We therefore need to employ a hack where we do the following:
- Check whether we're upgrading from a version that has the bug
- If we are, then enumerate through the .status files which are NOT being deleted
- For each status file, check whether the corresponding mrseq exists
- If it does not exist, then use the seqNo embedded in the status file name to recreate the .mrseq file