### PR TITLE
pull latest azure-extension-foundation - contains HIMDS changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/Azure/run-command-handler-linux
 
-go 1.22.1
-toolchain go1.24.1
+go 1.23.0
+
+toolchain go1.24.5
 
 require (
 	github.com/Azure/azure-extension-foundation v0.0.0-20250620154556-caff9e3c3c5c

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/Azure/azure-extension-foundation v0.0.0-20230404211847-9858bdd5c187 h1:C4S32XsUvctWzdWDEYlvhfcgH1iGvSD62II7Dd7F6B8=
-github.com/Azure/azure-extension-foundation v0.0.0-20230404211847-9858bdd5c187/go.mod h1:a0BFq9UoWBHvBS7iagvjFqBjYfxtBsmqvCLWIHRq9b0=
 github.com/Azure/azure-extension-foundation v0.0.0-20250620154556-caff9e3c3c5c h1:VJWgijxnboT//vE/2fvdERs0nn0Au5tWINvENmevp+8=
 github.com/Azure/azure-extension-foundation v0.0.0-20250620154556-caff9e3c3c5c/go.mod h1:sNC6lMTUkXwjrQ+nttr6GXhDfvSGT7t3UDq30BEYzu8=
 github.com/Azure/azure-extension-platform v0.0.0-20240610175536-404c704f82f8 h1:4AgLx0eXWAzh4nL7eBzwxoQaZEk5Hp2Ilq33YwYzEos=


### PR DESCRIPTION
run-command-handler-linux was using an older version of the azure-extension-foundation library. This PR pulls the latest from that repo, which includes support for HIMDS