### PR TITLE
Fixes unit test failures

### DIFF
--- a/internal/cmds/cmds.go
+++ b/internal/cmds/cmds.go
@@ -68,7 +68,8 @@ var (
 		"uninstall": CmdUninstall,
 	}
 
-	RunCmd = runCmd
+	RunCmd  = runCmd
+	DataDir = constants.DataDir
 
 	ErrAlreadyProcessed = errors.New("the script configuration has already been processed, will not run again")
 )
@@ -122,11 +123,11 @@ func install(ctx *log.Context, h types.HandlerEnvironment, report *types.RunComm
 		return "", "", err, exitCode
 	}
 
-	if err := os.MkdirAll(constants.DataDir, 0755); err != nil {
+	if err := os.MkdirAll(DataDir, 0755); err != nil {
 		return "", "", errors.Wrap(err, "failed to create data dir"), constants.ExitCode_CreateDataDirectoryFailed
 	}
 
-	ctx.Log("event", "created data dir", "path", constants.DataDir)
+	ctx.Log("event", "created data dir", "path", DataDir)
 	ctx.Log("event", "installed")
 	return "", "", nil, constants.ExitCode_Okay
 }
@@ -138,9 +139,9 @@ func uninstall(ctx *log.Context, h types.HandlerEnvironment, report *types.RunCo
 	}
 
 	{ // a new context scope with path
-		ctx = ctx.With("path", constants.DataDir)
-		ctx.Log("event", "removing data dir", "path", constants.DataDir)
-		if err := os.RemoveAll(constants.DataDir); err != nil {
+		ctx = ctx.With("path", DataDir)
+		ctx.Log("event", "removing data dir", "path", DataDir)
+		if err := os.RemoveAll(DataDir); err != nil {
 			return "", "", errors.Wrap(err, "failed to delete data directory"), constants.ExitCode_RemoveDataDirectoryFailed
 		}
 		ctx.Log("event", "removed data dir")

--- a/internal/cmds/cmds_test.go
+++ b/internal/cmds/cmds_test.go
@@ -178,6 +178,7 @@ func Test_checkAndSaveSeqNum(t *testing.T) {
 
 func Test_update_e2e_cmd(t *testing.T) {
 	tempDir, _ := os.MkdirTemp("", "deletecmd")
+	DataDir, _ = os.MkdirTemp("", "datadir")
 	oldVersionDirectory := filepath.Join(tempDir, "Microsoft.CPlat.Core.RunCommandHandlerLinux-1.3.8")
 	newVersionDirectory := filepath.Join(tempDir, "Microsoft.CPlat.Core.RunCommandHandlerLinux-1.3.9")
 	err := os.Mkdir(oldVersionDirectory, 0755)
@@ -229,6 +230,7 @@ func Test_update_e2e_cmd(t *testing.T) {
 
 func Test_udpate_e2e_problematic_version(t *testing.T) {
 	tempDir, _ := os.MkdirTemp("", "deletecmd")
+	DataDir, _ = os.MkdirTemp("", "datadir")
 	oldVersionDirectory := filepath.Join(tempDir, "Microsoft.CPlat.Core.RunCommandHandlerLinux-1.3.17")
 	newVersionDirectory := filepath.Join(tempDir, "Microsoft.CPlat.Core.RunCommandHandlerLinux-1.3.18")
 	err := os.Mkdir(oldVersionDirectory, 0755)
@@ -409,7 +411,7 @@ func Test_runCmd_success(t *testing.T) {
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	metadata := types.NewRCMetadata("extName", 0, constants.DownloadFolder, constants.DataDir)
+	metadata := types.NewRCMetadata("extName", 0, constants.DownloadFolder, DataDir)
 	err, exitCode := runCmd(log.NewContext(log.NewNopLogger()), dir, "", &handlersettings.HandlerSettings{
 		PublicSettings: handlersettings.PublicSettings{Source: &handlersettings.ScriptSource{Script: script}},
 	}, metadata)
@@ -435,7 +437,7 @@ func Test_runCmd_fail(t *testing.T) {
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	metadata := types.NewRCMetadata("extName", 0, constants.DownloadFolder, constants.DataDir)
+	metadata := types.NewRCMetadata("extName", 0, constants.DownloadFolder, DataDir)
 	err, exitCode := runCmd(log.NewContext(log.NewNopLogger()), dir, "", &handlersettings.HandlerSettings{
 		PublicSettings: handlersettings.PublicSettings{Source: &handlersettings.ScriptSource{Script: "non-existing-cmd"}},
 	}, metadata)
@@ -666,7 +668,7 @@ func Test_TreatFailureAsDeploymentFailureIsTrue_Fails(t *testing.T) {
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	metadata := types.NewRCMetadata("extName", 0, constants.DownloadFolder, constants.DataDir)
+	metadata := types.NewRCMetadata("extName", 0, constants.DownloadFolder, DataDir)
 	err, exitCode := runCmd(log.NewContext(log.NewNopLogger()), dir, "", &handlersettings.HandlerSettings{
 		PublicSettings: handlersettings.PublicSettings{Source: &handlersettings.ScriptSource{Script: script}, TreatFailureAsDeploymentFailure: true},
 	}, metadata)
@@ -685,7 +687,7 @@ func Test_TreatFailureAsDeploymentFailureIsTrue_SimpleScriptSucceeds(t *testing.
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	metadata := types.NewRCMetadata("extName", 0, constants.DownloadFolder, constants.DataDir)
+	metadata := types.NewRCMetadata("extName", 0, constants.DownloadFolder, DataDir)
 	err, exitCode := runCmd(log.NewContext(log.NewNopLogger()), dir, "", &handlersettings.HandlerSettings{
 		PublicSettings: handlersettings.PublicSettings{Source: &handlersettings.ScriptSource{Script: script}, TreatFailureAsDeploymentFailure: false},
 	}, metadata)


### PR DESCRIPTION
The new unit tests were failing because we tried to delete the DataDir, which on Azure machines is not allowed.
Added ability for tests to change the location of the DataDir so we can delete it.