### PR TITLE
Adds extension events to RCV2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.5
 
 require (
 	github.com/Azure/azure-extension-foundation v0.0.0-20250620154556-caff9e3c3c5c
-	github.com/Azure/azure-extension-platform v0.0.0-20240610175536-404c704f82f8
+	github.com/Azure/azure-extension-platform v0.0.0-20250107200156-aa20f765d49f
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.16.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Azure/azure-extension-foundation v0.0.0-20250620154556-caff9e3c3c5c h
 github.com/Azure/azure-extension-foundation v0.0.0-20250620154556-caff9e3c3c5c/go.mod h1:sNC6lMTUkXwjrQ+nttr6GXhDfvSGT7t3UDq30BEYzu8=
 github.com/Azure/azure-extension-platform v0.0.0-20240610175536-404c704f82f8 h1:4AgLx0eXWAzh4nL7eBzwxoQaZEk5Hp2Ilq33YwYzEos=
 github.com/Azure/azure-extension-platform v0.0.0-20240610175536-404c704f82f8/go.mod h1:nEQQIC3RKmMnpdc+RakYHIdu556jdcHv67ML8PdsQeQ=
+github.com/Azure/azure-extension-platform v0.0.0-20250107200156-aa20f765d49f h1:ddsUz/suc9txCMz/xWOslqNMvzhbWFMTflUrbcMNoSw=
+github.com/Azure/azure-extension-platform v0.0.0-20250107200156-aa20f765d49f/go.mod h1:0458BvQsi5ch6kn+KZtI5m88Z3L9UFXdoY1+6nKdivY=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.16.0 h1:JZg6HRh6W6U4OLl6lk7BZ7BLisIzM9dG1R50zUk9C/M=

--- a/internal/cmds/cmds_test.go
+++ b/internal/cmds/cmds_test.go
@@ -7,11 +7,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-extension-platform/pkg/extensionevents"
+	"github.com/Azure/azure-extension-platform/pkg/handlerenv"
+	"github.com/Azure/azure-extension-platform/pkg/logging"
 	"github.com/Azure/run-command-handler-linux/internal/constants"
 	"github.com/Azure/run-command-handler-linux/internal/files"
 	"github.com/Azure/run-command-handler-linux/internal/handlersettings"
@@ -74,7 +78,13 @@ func Test_CopyMrseqFiles_MrseqFilesAreCopied(t *testing.T) {
 	os.Create(filepath.Join(previousStatusDirectory, "ABCD.1.status"))
 	os.Create(filepath.Join(previousStatusDirectory, "abc.cs")) // this should not be copied to currentExtensionVersionDirectory
 
-	err = CopyStateForUpdate(log.NewContext(log.NewNopLogger()))
+	handlerEnvironment := handlerenv.HandlerEnvironment{
+		EventsFolder: path.Join(currentExtensionVersionDirectory, "events"),
+	}
+
+	extensionLogger := logging.New(nil)
+	extensionEventManager := extensionevents.New(extensionLogger, &handlerEnvironment)
+	err = CopyStateForUpdate(log.NewContext(log.NewNopLogger()), extensionEventManager)
 	require.Nil(t, err)
 
 	files, _ = ioutil.ReadDir(currentExtensionVersionDirectory)

--- a/internal/commandProcessor/commandProcessor.go
+++ b/internal/commandProcessor/commandProcessor.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-extension-platform/pkg/handlerenv"
 	"github.com/Azure/azure-extension-platform/pkg/logging"
 	"github.com/Azure/run-command-handler-linux/internal/constants"
 	"github.com/Azure/run-command-handler-linux/internal/handlersettings"
@@ -17,6 +18,10 @@ import (
 	"github.com/Azure/run-command-handler-linux/pkg/versionutil"
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
+)
+
+var (
+	handlerEnvironmentGetter func(name, version string) (he *handlerenv.HandlerEnvironment, _ error) = handlerenv.GetHandlerEnvironment
 )
 
 func ProcessImmediateHandlerCommand(cmd types.Cmd, hs handlersettings.HandlerSettingsFile, extensionName string, seqNum int) error {

--- a/internal/types/handlerenvironment.go
+++ b/internal/types/handlerenvironment.go
@@ -6,9 +6,15 @@ type HandlerEnvironment struct {
 	Version            float64 `json:"version"`
 	Name               string  `json:"name"`
 	HandlerEnvironment struct {
-		HeartbeatFile string `json:"heartbeatFile"`
-		StatusFolder  string `json:"statusFolder"`
-		ConfigFolder  string `json:"configFolder"`
-		LogFolder     string `json:"logFolder"`
+		HeartbeatFile       string `json:"heartbeatFile"`
+		StatusFolder        string `json:"statusFolder"`
+		ConfigFolder        string `json:"configFolder"`
+		LogFolder           string `json:"logFolder"`
+		EventsFolder        string `json:"eventsFolder"`
+		EventsFolderPreview string `json:"eventsFolder_preview"`
+		DeploymentID        string `json:"deploymentid"`
+		RoleName            string `json:"rolename"`
+		Instance            string `json:"instance"`
+		HostResolverAddress string `json:"hostResolverAddress"`
 	}
 }


### PR DESCRIPTION
Extension events write events to a file, which Guest Agent then picks up and they're eventually queryable in Kusto.
This will make debugging RCV2 Linux issues much easier.

Uses the extensions platform for the extension events capability. This requires translating the handler manifest between the two platforms.