### PR TITLE
Use fuser instead of lsof command in run-command-shim to prevent run commands hanging due to lsof command hanging

### DIFF
--- a/misc/run-command-shim
+++ b/misc/run-command-shim
@@ -47,7 +47,7 @@ fi
 
 ### Retry logic to acquire lock and execute the command
 set +e # disable exit on non-zero return code
-local retry_attempts=0
+retry_attempts=0
 
 # Create lock file if it does not exist
 if [ ! -f "$LOCKFILE" ]; then
@@ -55,13 +55,12 @@ if [ ! -f "$LOCKFILE" ]; then
     echo "Lock file $LOCKFILE has been created."
 fi
 
+set -x
 while (( retry_attempts < 10 )); do
-    set -x
     # Acquire the exclusive (-x) and non-blocking (-n) lock on the lock file and execute $commandToExecute(side note: flock is part of util-linux package and is available by default on most Linux distros)
     flock -x -n "$LOCKFILE" -c "$commandToExecute"
     flock_status=$? # Capture the exit status of the flock command
-    set +x
-    
+
     if [ $flock_status -eq 1 ]; then
         echo "Lock already held by another process. Retrying..."
         ((++retry_attempts))
@@ -77,6 +76,7 @@ while (( retry_attempts < 10 )); do
         break
     fi
 done
+set +x
 ### End of retry logic
 
 # Do not return error if lock not acquired even after retries expire, make a best effort attempt to start run-command-handler

--- a/misc/run-command-shim
+++ b/misc/run-command-shim
@@ -20,38 +20,6 @@ echo Architecture: $ARCHITECTURE
 echo Binary: $HANDLER_BIN
 LOCK_ACQUIRED=0
 
-get_lock() {
-    set +e # disable exit on non-zero return code
-    local retry_attempts=0
-
-    # Create lock file if it does not exist
-    if [ ! -f "$LOCKFILE" ]; then
-        touch "$LOCKFILE"
-        echo "Lock file '$LOCKFILE' has been created."
-    fi
- 
-    while (( retry_attempts < 10 )); do
-        # Acquire the exclusive (-x) and non-blocking (-n) lock on the lock file (side note: flock is part of util-linux package and is available by default on most Linux distros)
-        if ! flock -x -n $LOCKFILE; then
-            echo "Lock already held by another process. Retrying..."
-            ((++retry_attempts))
-            echo "sleeping for 3 seconds before retry, attempt ${retry_attempts} of 10"
-            sleep 3
-            continue
-        else
-            echo "Lock acquired on file '$LOCKFILE'"
-            LOCK_ACQUIRED=1
-            break
-        fi
-    done
-    # Do not return error if lock not acquired even after retries expire, make a best effort attempt to start run-command-handler
-    if [ "$LOCK_ACQUIRED" -eq 0 ]; then
-        echo "Lock was not acquired on '$LOCKFILE' after retries. Making best-effort attempt to start run-command-handler..."
-    fi
-    set -e
-    return 0
-}
-
 if [ "$#" -ne 1 ]; then
     echo "Incorrect usage."
     echo "Usage: $0 <command>"
@@ -66,18 +34,58 @@ exec &> >(tee -ia "$LOG_DIR/$LOG_FILE")
 bin="$(readlink -f "$SCRIPT_DIR/$HANDLER_BIN")"
 cmd="$1"
 
+# For commands other than 'enable', execute the handler process as a child process
+commandToExecute = "$bin $cmd"
+
 if [[ "$cmd" == "enable" ]]; then
     # for 'enable' command, double fork
     # to detach from the handler process tree to avoid getting terminated 
     # after the 15-minute extension enabling timeout.
-    get_lock
-    set -x
-    # & will execute the binary on the backgraound and will not block current shell execution
-    nohup "$bin" "$cmd" &
-else
-    # execute the handler process as a child process
-    get_lock
-    set -x
-    "$bin" "$cmd"
+    # & will execute the binary on the background and will not block current shell execution
+    commandToExecute = "nohup $bin $cmd &"
 fi
+
+### Retry logic to acquire lock and execute the command
+set +e # disable exit on non-zero return code
+local retry_attempts=0
+
+# Create lock file if it does not exist
+if [ ! -f "$LOCKFILE" ]; then
+    touch "$LOCKFILE"
+    echo "Lock file '$LOCKFILE' has been created."
+fi
+
+while (( retry_attempts < 10 )); do
+    set -x
+    # Acquire the exclusive (-x) and non-blocking (-n) lock on the lock file and execute $commandToExecute(side note: flock is part of util-linux package and is available by default on most Linux distros)
+    flock -x -n "$LOCKFILE" -c "$commandToExecute"
+    flock_status=$? # Capture the exit status of the flock command
+    set +x
+    
+    if [ $flock_status -eq 1 ]; then
+        echo "Lock already held by another process. Retrying..."
+        ((++retry_attempts))
+        echo "sleeping for 3 seconds before retry, attempt ${retry_attempts} of 10"
+        sleep 3
+        continue
+    elif [ $flock_status -eq 0 ]; then
+        LOCK_ACQUIRED=1
+        echo "Lock acquired on file '$LOCKFILE' and executed command '$commandToExecute' successfully. Exiting."
+        break
+    else
+        echo "Failed to execute command '$commandToExecute' with flock on file '$LOCKFILE'. Exiting with exit code $flock_status"         
+        break
+    fi
+done
+### End of retry logic
+
+# Do not return error if lock not acquired even after retries expire, make a best effort attempt to start run-command-handler
+if [ "$LOCK_ACQUIRED" -eq 0 ]; then
+    echo "Lock was not acquired on '$LOCKFILE' after retries. Making best-effort attempt to start run-command-handler..."
+    set -x
+    $commandToExecute
+    set +x
+fi
+set -e
+
 # Exiting the script releases the lock on $LOCKFILE by closing the file descriptor associated with the lock.

--- a/misc/run-command-shim
+++ b/misc/run-command-shim
@@ -35,14 +35,14 @@ bin="$(readlink -f "$SCRIPT_DIR/$HANDLER_BIN")"
 cmd="$1"
 
 # For commands other than 'enable', execute the handler process as a child process
-commandToExecute = "${bin} ${cmd}"
+commandToExecute="$bin $cmd"
 
 if [[ "$cmd" == "enable" ]]; then
     # for 'enable' command, double fork
     # to detach from the handler process tree to avoid getting terminated 
     # after the 15-minute extension enabling timeout.
     # & will execute the binary on the background and will not block current shell execution
-    commandToExecute = "nohup ${bin} ${cmd} &"
+    commandToExecute="nohup $bin $cmd &"
 fi
 
 ### Retry logic to acquire lock and execute the command

--- a/misc/run-command-shim
+++ b/misc/run-command-shim
@@ -13,49 +13,41 @@ fi
 # in multiconfig case $ConfigExtensionName and $ConfigSequenceNumber should be set by the agent
 readonly EXTENSION_NAME=$ConfigExtensionName
 readonly SEQNO=$ConfigSequenceNumber
+readonly LOCKFILE="./run-command-handler.lock"
 echo "ConfigExtensionName: $EXTENSION_NAME"
 echo "ConfigSequenceNumber: $SEQNO"
 echo Architecture: $ARCHITECTURE
 echo Binary: $HANDLER_BIN
+LOCK_ACQUIRED=0
 
-check_binary_write_lock() {
+get_lock() {
     set +e # disable exit on non-zero return code
     local retry_attempts=0
-    while (( retry_attempts < 10 )); do
-        lsof_result="$(lsof -F ac ${bin})"
-        lsof_return_code=$?
-        if [ "$lsof_return_code" -eq 0 ]; then
-            #"lsof -F" outputs results in more parse-able format, "-F ac" option prints access mode and command name for process
-            #access mode and command names are prepended with a and c
-            file_mode="$(echo "$lsof_result" | awk 'match($0, /^a(.*)$/) {print $0}')"
-            process_name="$(echo "$lsof_result" | awk 'match($0, /^c(.*)$/) {print substr($0, RSTART+1, RLENGTH-1)}')"
 
-            found_write_lock=0
-            file_mode_array=($file_mode)
-            i=0
-            for name in $process_name
-            do
-                file_handle_mode=${file_mode_array[$i]}
-                echo "$name has access mode '$file_handle_mode' file handle on ${HANDLER_BIN}"
-                ## w and u are file descriptor modes for write and read/write access
-                if [[ $file_handle_mode == "aw" ]] || [[ $file_handle_mode == "au" ]]; then
-                    found_write_lock=1
-                fi
-                ((++i))
-            done
-            if [ "$found_write_lock" -eq 0 ]; then
-                # did not find write lock on any file no need to wait or retry
-                break
-            fi
+    # Create lock file if it does not exist
+    if [ ! -f "$LOCKFILE" ]; then
+        touch "$LOCKFILE"
+        echo "Lock file '$LOCKFILE' has been created."
+    fi
+ 
+    while (( retry_attempts < 10 )); do
+        # Acquire the exclusive (-x) and non-blocking (-n) lock on the lock file (side note: flock is part of util-linux package and is available by default on most Linux distros)
+        if ! flock -x -n $LOCKFILE; then
+            echo "Lock already held by another process. Retrying..."
             ((++retry_attempts))
-            echo "waiting for process(es) with write handle on ${HANDLER_BIN}"
             echo "sleeping for 3 seconds before retry, attempt ${retry_attempts} of 10"
             sleep 3
+            continue
         else
+            echo "Lock acquired on file '$LOCKFILE'"
+            LOCK_ACQUIRED=1
             break
         fi
     done
-    # do not return error if file descriptor is open after retries expire, make a best effort attempt to start custom-script-extension
+    # Do not return error if lock not acquired even after retries expire, make a best effort attempt to start run-command-handler
+    if [ "$LOCK_ACQUIRED" -eq 0 ]; then
+        echo "Lock was not acquired on '$LOCKFILE' after retries. Making best-effort attempt to start run-command-handler..."
+    fi
     set -e
     return 0
 }
@@ -78,13 +70,14 @@ if [[ "$cmd" == "enable" ]]; then
     # for 'enable' command, double fork
     # to detach from the handler process tree to avoid getting terminated 
     # after the 15-minute extension enabling timeout.
-    check_binary_write_lock
+    get_lock
     set -x
     # & will execute the binary on the backgraound and will not block current shell execution
     nohup "$bin" "$cmd" &
 else
     # execute the handler process as a child process
-    check_binary_write_lock
+    get_lock
     set -x
     "$bin" "$cmd"
 fi
+# Exiting the script releases the lock on $LOCKFILE by closing the file descriptor associated with the lock.

--- a/misc/run-command-shim
+++ b/misc/run-command-shim
@@ -35,14 +35,14 @@ bin="$(readlink -f "$SCRIPT_DIR/$HANDLER_BIN")"
 cmd="$1"
 
 # For commands other than 'enable', execute the handler process as a child process
-commandToExecute = "$bin $cmd"
+commandToExecute = "${bin} ${cmd}"
 
 if [[ "$cmd" == "enable" ]]; then
     # for 'enable' command, double fork
     # to detach from the handler process tree to avoid getting terminated 
     # after the 15-minute extension enabling timeout.
     # & will execute the binary on the background and will not block current shell execution
-    commandToExecute = "nohup $bin $cmd &"
+    commandToExecute = "nohup ${bin} ${cmd} &"
 fi
 
 ### Retry logic to acquire lock and execute the command
@@ -52,7 +52,7 @@ local retry_attempts=0
 # Create lock file if it does not exist
 if [ ! -f "$LOCKFILE" ]; then
     touch "$LOCKFILE"
-    echo "Lock file '$LOCKFILE' has been created."
+    echo "Lock file $LOCKFILE has been created."
 fi
 
 while (( retry_attempts < 10 )); do
@@ -70,10 +70,10 @@ while (( retry_attempts < 10 )); do
         continue
     elif [ $flock_status -eq 0 ]; then
         LOCK_ACQUIRED=1
-        echo "Lock acquired on file '$LOCKFILE' and executed command '$commandToExecute' successfully. Exiting."
+        echo "Lock acquired on file $LOCKFILE and executed command $commandToExecute successfully. Exiting."
         break
     else
-        echo "Failed to execute command '$commandToExecute' with flock on file '$LOCKFILE'. Exiting with exit code $flock_status"         
+        echo "Failed to execute command $commandToExecute with flock on file $LOCKFILE. Exiting with exit code $flock_status"         
         break
     fi
 done
@@ -81,7 +81,7 @@ done
 
 # Do not return error if lock not acquired even after retries expire, make a best effort attempt to start run-command-handler
 if [ "$LOCK_ACQUIRED" -eq 0 ]; then
-    echo "Lock was not acquired on '$LOCKFILE' after retries. Making best-effort attempt to start run-command-handler..."
+    echo "Lock was not acquired on $LOCKFILE after retries. Making best-effort attempt to start run-command-handler..."
     set -x
     $commandToExecute
     set +x

--- a/misc/run-command-shim
+++ b/misc/run-command-shim
@@ -34,14 +34,14 @@ bin="$(readlink -f "$SCRIPT_DIR/$HANDLER_BIN")"
 cmd="$1"
 
 # For commands other than 'enable', execute the handler process as a child process
-commandToExecute="$bin $cmd"
+commandToExecute="'$bin' '$cmd'"
 
 if [[ "$cmd" == "enable" ]]; then
     # for 'enable' command, double fork
     # to detach from the handler process tree to avoid getting terminated 
     # after the 15-minute extension enabling timeout.
     # & will execute the binary on the background and will not block current shell execution
-    commandToExecute="nohup $bin $cmd &"
+    commandToExecute="nohup '$bin' '$cmd' &"
 fi
 
 ### Retry logic to check if RunCommand binary is open for write and execute the command
@@ -49,14 +49,14 @@ set +e # disable exit on non-zero return code
 retry_attempts=0
 
 set -x
-if command -v fuser &>/dev/null; then
+if command -v fuser &>/dev/null; then # check if fuser command is available
     while (( retry_attempts < 10 )); do
         # Use fuser to detect if the run command binary is open for write to help detect potential conflicts like 'text file busy' errors that prevents execution of Run Command binary.
         fuser_output=$(fuser -vw "$bin" 2>&1)
         fuser_status=$?
         
         # Use 10 retries with 3 seconds sleep between retries to allow for any potential conflicts to resolve before executing the Run Command binary.
-        if [ $fuser_status -eq 0 ]; then
+        if [ $fuser_status -eq 0 ]; then # atleast one process was found which has opened the binary in write mode.
             echo "RunCommand binary $bin is open for write. User(s) with write access:"
             echo "$fuser_output"
             echo "Binary is open for write. Allowing execution via best-effort path after all retries have been exhausted..."
@@ -64,18 +64,19 @@ if command -v fuser &>/dev/null; then
             echo "sleeping for 3 seconds before retry, attempt ${retry_attempts} of 10"
             sleep 3
             continue
-        else
+        elif [ $fuser_status -eq 1 ]; then
             echo "Binary $bin is not open for write. All good. Proceeding with execution..."         
+            break
+        else
+            echo "Unexpected fuser error with error code $fuser_status while checking if $bin is open for write using fuser command. Proceeding with best-effort execution..."
             break
         fi
     done
 else
     echo "INFO: Not an error. fuser command not found. Install 'psmic' package to use fuser for checking if the Run Command binary is open for write to detect potential conflicts like 'text file busy' errors while executing Run Command binary. Proceeding with best-effort execution..."
 fi
-set +x
 ### End of retry logic
 
-set -x
 echo "Starting run-command-handler..."
 $commandToExecute
 echo "run-command-handler finished."

--- a/misc/run-command-shim
+++ b/misc/run-command-shim
@@ -13,12 +13,11 @@ fi
 # in multiconfig case $ConfigExtensionName and $ConfigSequenceNumber should be set by the agent
 readonly EXTENSION_NAME=$ConfigExtensionName
 readonly SEQNO=$ConfigSequenceNumber
-readonly LOCKFILE="./run-command-handler.lock"
+
 echo "ConfigExtensionName: $EXTENSION_NAME"
 echo "ConfigSequenceNumber: $SEQNO"
 echo Architecture: $ARCHITECTURE
 echo Binary: $HANDLER_BIN
-LOCK_ACQUIRED=0
 
 if [ "$#" -ne 1 ]; then
     echo "Incorrect usage."
@@ -45,47 +44,41 @@ if [[ "$cmd" == "enable" ]]; then
     commandToExecute="nohup $bin $cmd &"
 fi
 
-### Retry logic to acquire lock and execute the command
+### Retry logic to check if RunCommand binary is open for write and execute the command
 set +e # disable exit on non-zero return code
 retry_attempts=0
 
-# Create lock file if it does not exist
-if [ ! -f "$LOCKFILE" ]; then
-    touch "$LOCKFILE"
-    echo "Lock file $LOCKFILE has been created."
-fi
-
 set -x
-while (( retry_attempts < 10 )); do
-    # Acquire the exclusive (-x) and non-blocking (-n) lock on the lock file and execute $commandToExecute(side note: flock is part of util-linux package and is available by default on most Linux distros)
-    flock -x -n "$LOCKFILE" -c "$commandToExecute"
-    flock_status=$? # Capture the exit status of the flock command
-
-    if [ $flock_status -eq 1 ]; then
-        echo "Lock already held by another process. Retrying..."
-        ((++retry_attempts))
-        echo "sleeping for 3 seconds before retry, attempt ${retry_attempts} of 10"
-        sleep 3
-        continue
-    elif [ $flock_status -eq 0 ]; then
-        LOCK_ACQUIRED=1
-        echo "Lock acquired on file $LOCKFILE and executed command $commandToExecute successfully. Exiting."
-        break
-    else
-        echo "Failed to execute command $commandToExecute with flock on file $LOCKFILE. Exiting with exit code $flock_status"         
-        break
-    fi
-done
+if command -v fuser &>/dev/null; then
+    while (( retry_attempts < 10 )); do
+        # Use fuser to detect if the run command binary is open for write to help detect potential conflicts like 'text file busy' errors that prevents execution of Run Command binary.
+        fuser_output=$(fuser -vw "$bin" 2>&1)
+        fuser_status=$?
+        
+        # Use 10 retries with 3 seconds sleep between retries to allow for any potential conflicts to resolve before executing the Run Command binary.
+        if [ $fuser_status -eq 0 ]; then
+            echo "RunCommand binary $bin is open for write. User(s) with write access:"
+            echo "$fuser_output"
+            echo "Binary is open for write. Allowing execution via best-effort path after all retries have been exhausted..."
+            ((++retry_attempts))
+            echo "sleeping for 3 seconds before retry, attempt ${retry_attempts} of 10"
+            sleep 3
+            continue
+        else
+            echo "Binary $bin is not open for write. All good. Proceeding with execution..."         
+            break
+        fi
+    done
+else
+    echo "INFO: Not an error. fuser command not found. Install 'psmic' package to use fuser for checking if the Run Command binary is open for write to detect potential conflicts like 'text file busy' errors while executing Run Command binary. Proceeding with best-effort execution..."
+fi
 set +x
 ### End of retry logic
 
-# Do not return error if lock not acquired even after retries expire, make a best effort attempt to start run-command-handler
-if [ "$LOCK_ACQUIRED" -eq 0 ]; then
-    echo "Lock was not acquired on $LOCKFILE after retries. Making best-effort attempt to start run-command-handler..."
-    set -x
-    $commandToExecute
-    set +x
-fi
-set -e
+set -x
+echo "Starting run-command-handler..."
+$commandToExecute
+echo "run-command-handler finished."
+set +x
 
-# Exiting the script releases the lock on $LOCKFILE by closing the file descriptor associated with the lock.
+set -e

--- a/misc/run-command-shim
+++ b/misc/run-command-shim
@@ -27,7 +27,7 @@ fi
 
 # Redirect logs of the handler process
 mkdir -p "$LOG_DIR"
-exec &> >(tee -ia "$LOG_DIR/$LOG_FILE")
+exec &> >(tee -ia "$LOG_DIR/$LOG_FILE") 2>&1
 
 # Start handling the process in the background
 bin="$(readlink -f "$SCRIPT_DIR/$HANDLER_BIN")"

--- a/misc/run-command-shim
+++ b/misc/run-command-shim
@@ -27,7 +27,7 @@ fi
 
 # Redirect logs of the handler process
 mkdir -p "$LOG_DIR"
-exec &> >(tee -ia "$LOG_DIR/$LOG_FILE") 2>&1
+exec &> >(tee -ia "$LOG_DIR/$LOG_FILE")
 
 # Start handling the process in the background
 bin="$(readlink -f "$SCRIPT_DIR/$HANDLER_BIN")"


### PR DESCRIPTION
**Problem(s)**:
  - lsof command hanging during execution of run-command-shim for 3P customers Chevron, CapGemini. This hang has caused timeouts with Run Command v1 Linux (even before executing the user's script)
ICM incidents mentioned here [Task 34627514](https://msazure.visualstudio.com/One/_workitems/edit/34627514): Investigate RCv2 Linux NOT using lsof command OR using alternatives (lsof command hanging)
- "lsof command not found" error due to its package not installed

**Background**:
-  lsof command is being used currently in shim file of extensions (Run command v1, v2, custom script) to prevent issues caused by race conditions
- lsof command in shim is used to "list open files by the run command binary run-command-handler". If there are any open files already, we do not run the script, we wait and retry today.
- lsof is performance-intensive (lists processes, examines all file descriptors and symbolic links. It can get stuck if there are issues examining file descriptors on an unavailable/unresponsive mount, Network file system , DNS timeouts on name resolution of IPs). This can cause hang issues on high load servers of our customers

**Solution**
- Use fuser command instead to detect any conflicts like "text file busy" error before executing RC (do not use lsof)
- fuser command also outputs what has the run command binary open in write mode
- If fuser command not available on VM, it executes the script anyways as best-effort execution. 

**Sample execution from log**:

**Simulation of "Text file busy" error** (RC binary is open in write mode)
sleeping for 3 seconds before retry, attempt 9 of 10
bash has access mode 'aw' file handle on run-command-handler
sleep has access mode 'aw' file handle on run-command-handler
waiting for process(es) with write handle on run-command-handler
sleeping for 3 seconds before retry, attempt 10 of 10
+ nohup /var/lib/waagent/Microsoft.CPlat.Core.RunCommandHandlerLinux-1.3.28/bin/run-command-handler enable
nohup: failed to run command '/var/lib/waagent/Microsoft.CPlat.Core.RunCommandHandlerLinux-1.3.28/bin/run-command-handler': **Text file busy**
[stderr]

**Successful case** (RC executed fine )
2026-08-04T03:14:15.300891Z INFO ExtHandler [Microsoft.CPlat.Core.RunCommandHandlerLinux.RC0803_4-1.3.28] Command: bin/run-command-shim enable
[stdout]
t.CPlat.Core.RunCommandHandlerLinux-1.3.28/bin/run-command-handler enable
time=2026-08-04T03:14:13Z version=v/git@- operation=enable event=start
time=2026-08-04T03:14:13Z version=v/git@- operation=enable message="processing command"
time=2026-08-04T03:14:13Z version=v/git@- operation=enable message="getting required initial variables"
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4
time=2026-08-04T03:14:13Z version=v/git@- operation=enable seq=0 seqNum=0
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4 event=pre-check
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4 event="comparing seqnum" path=RC0803_4.mrseq
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4 event="seqnum saved" path=RC0803_4.mrseq
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4 message="processing command for extensionName: RC0803_4 and seqNum: 0"
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4 message="creating json to report status"
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4 message="reporting status by writing status file locally"
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4 message="Run Command status was written to file successfully."
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4 event="reading configuration from /var/lib/waagent/Microsoft.CPlat.Core.RunCommandHandlerLinux-1.3.28/config/RC0803_4.0.settings"
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4 event="read configuration"
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4 event="parsing configuration json"
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4 event="parsed configuration json"
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4 event="validating configuration logically"
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4 event="validated configuration"
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4 message="extension policy settings file does not exist. No policy applied." error="stat /var/lib/waagent/Microsoft.CPlat.Core.RunCommandHandlerLinux-1.3.28/config/waagent_runtime_policy.json: no such file or directory"
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4 event="creating output directory" path=/var/lib/waagent/run-command-handler/download/RC0803_4/0
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4 event="created output directory"
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4 scriptUri=
time=2026-08-04T03:14:13Z version=v/git@- operation=enable extensionName=RC0803_4 event="executing command" output=/var/lib/waagent/run-command-handler/download/RC0803_4/0
time=2026-







