### PR TITLE
Proceed with execution even if policy file invalid 

### DIFF
--- a/internal/cmds/cmds.go
+++ b/internal/cmds/cmds.go
@@ -225,9 +225,10 @@ func enable(ctx *log.Context, h types.HandlerEnvironment, report *types.RunComma
 		if err != nil {
 			// TODO: In the future, fail the command if the policy file was invalid and return the exitCode.
 			// For now, log the error and continue with the command execution.
-			ctx.Log("error", "failed to initialize extension policy settings. No policy applied.", "error", err, "errorCode", exitCode)
+			ctx.Log("error", "failed to initialize extension policy settings. Executing command with no policy applied for now.", "error", err, "errorCode", exitCode)
+		} else {
+			ctx.Log("message", "successfully initialized extension policy settings")
 		}
-		ctx.Log("message", "successfully initialized extension policy settings")
 	} else if os.IsNotExist(err) {
 		ctx.Log("message", "extension policy settings file does not exist. No policy applied.", "error", err)
 		extensionPolicyManagerPtr = nil

--- a/internal/cmds/cmds.go
+++ b/internal/cmds/cmds.go
@@ -223,7 +223,9 @@ func enable(ctx *log.Context, h types.HandlerEnvironment, report *types.RunComma
 	if _, err := os.Stat(policyPath); err == nil {
 		extensionPolicyManagerPtr, rceps, err, exitCode = extensionpolicysettingsrc.InitializeExtensionPolicySettings(ctx, policyPath)
 		if err != nil {
-			return "", "", err, exitCode
+			// TODO: In the future, fail the command if the policy file was invalid and return the exitCode.
+			// For now, log the error and continue with the command execution.
+			ctx.Log("error", "failed to initialize extension policy settings. No policy applied.", "error", err, "errorCode", exitCode)
 		}
 		ctx.Log("message", "successfully initialized extension policy settings")
 	} else if os.IsNotExist(err) {

--- a/internal/cmds/cmds_test.go
+++ b/internal/cmds/cmds_test.go
@@ -1694,3 +1694,52 @@ func Test_enable_e2e_extension_policy_settings_block_statusfail(t *testing.T) {
 	require.Equal(t, types.StatusError, report[0].Status.Status, "status report should indicate failure")
 	require.True(t, strings.Contains(report[0].Status.FormattedMessage.Message, "executionState\":\"Failed\",\"executionMessage\":\"Execution failed"), "execution message should indicate failure")
 }
+
+// This test verifies that an invalid policy file does not block execution,
+// and the extension proceeds with no policy applied.
+func Test_enable_e2e_extension_policy_settings_corrupt_policy_continues(t *testing.T) {
+	// Two primary scenarios for corrupt policy: empty file and invalid JSON.
+	corruptPolicies := map[string][]byte{
+		"empty file":   {},
+		"invalid json": []byte("{ this is not valid json"),
+	}
+
+	for name, corruptContent := range corruptPolicies {
+		t.Run(name, func(t *testing.T) {
+			ctx := log.NewContext(log.NewNopLogger())
+			extName, seqNum := "corruptPolicyRun", 0
+			scriptContent := []byte("#!/bin/bash\necho hello\n")
+
+			srv := make_server_with_content(scriptContent)
+			defer srv.Close()
+
+			dataDir, err := os.MkdirTemp("", "policy-corrupt")
+			require.Nil(t, err)
+			defer os.RemoveAll(dataDir)
+
+			// Create a valid environment first, then overwrite the policy file with corrupt content.
+			policy := &extensionpolicysettingsrc.RCv2ExtensionPolicySettings{
+				LimitScripts: "alloweddownloaded",
+			}
+			fakeEnv := setupPolicyE2E(t, dataDir, extName, seqNum, srv.URL+"/script.sh", false, policy)
+
+			// Corrupt the policy file so that loading/parsing it fails.
+			policyFilePath := filepath.Join(fakeEnv.HandlerEnvironment.ConfigFolder, constants.PolicyFileName)
+			require.Nil(t, os.WriteFile(policyFilePath, corruptContent, 0600), "could not write corrupt policy file")
+
+			scriptWasExecuted := false
+			RunCmd = func(ctx *log.Context, dir, scriptFilePath string, cfg *handlersettings.HandlerSettings, metadata types.RCMetadata) (error, int) {
+				scriptWasExecuted = true
+				return nil, 0
+			}
+
+			err = commandProcessor.ProcessHandlerCommandWithDetails(ctx, CmdEnable, fakeEnv, extName, seqNum, constants.DownloadFolder, dataDir)
+			require.Nil(t, err, "enable command should succeed despite corrupt policy")
+			require.True(t, scriptWasExecuted, "script should still be executed when policy is corrupt")
+
+			report := readStatusReport(t, fakeEnv, extName, seqNum) // verify status report exists and is valid
+			require.Equal(t, types.StatusSuccess, report[0].Status.Status, "status report should indicate success")
+			require.True(t, strings.Contains(report[0].Status.FormattedMessage.Message, "executionState\":\"Succeeded\",\"executionMessage\":\"Execution completed"), "execution message should indicate success")
+		})
+	}
+}

--- a/internal/cmds/cmds_test.go
+++ b/internal/cmds/cmds_test.go
@@ -1723,7 +1723,7 @@ func Test_enable_e2e_extension_policy_settings_corrupt_policy_continues(t *testi
 			policy := &extensionpolicysettingsrc.RCv2ExtensionPolicySettings{
 				LimitScripts: "alloweddownloaded",
 			}
-			fakeEnv := setupPolicyE2E(t, dataDir, extName, seqNum, srv.URL+"/script.sh", false, policy)
+			fakeEnv := setupPolicyE2E(t, dataDir, extName, seqNum, srv.URL+"/script.sh", false, "", "", policy)
 
 			// Corrupt the policy file so that loading/parsing it fails.
 			policyFilePath := filepath.Join(fakeEnv.HandlerEnvironment.ConfigFolder, constants.PolicyFileName)


### PR DESCRIPTION
**Overview:**
Part of the constrained extensions code involves reading a policy file (the file that contains the policy rules for the extension). Previously, if the file was corrupt (invalid JSON, empty/cleared file), then the extension would log the error and exit. 

However, all the constrained extensions feature work is new, and we should err on the side of caution. Thus, for now if the policy file is invalid, we log the error but continue execution with no policy applied. This change matches the code changes made [here](https://dev.azure.com/msazure/One/_git/Compute-ART-Extensions/pullrequest/15005735?path=/src/RunCommandHandler/src/RunCommandHandler.Common/GoalStateExecutorBase.cs&version=GBmaster&line=78&lineEnd=82&lineStartColumn=1&lineEndColumn=14&type=2&lineStyle=plain&_a=files&iteration=18&base=0) in RCv2 Windows.

**PR includes:**
* error log for when policy file invalid
* UTs to ensure extension still succeeds + script is executed